### PR TITLE
Rename `shcrs` to `shcsr` in `scb::RegisterBlock`

### DIFF
--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -51,7 +51,7 @@ pub struct RegisterBlock {
     pub shpr: [RW<u32>; 2],
 
     /// System Handler Control and State
-    pub shcrs: RW<u32>,
+    pub shcsr: RW<u32>,
 
     /// Configurable Fault Status (not present on Cortex-M0 variants)
     #[cfg(not(armv6m))]

--- a/src/peripheral/test.rs
+++ b/src/peripheral/test.rs
@@ -121,7 +121,7 @@ fn scb() {
     assert_eq!(address(&scb.scr), 0xE000_ED10);
     assert_eq!(address(&scb.ccr), 0xE000_ED14);
     assert_eq!(address(&scb.shpr), 0xE000_ED18);
-    assert_eq!(address(&scb.shcrs), 0xE000_ED24);
+    assert_eq!(address(&scb.shcsr), 0xE000_ED24);
     assert_eq!(address(&scb.cfsr), 0xE000_ED28);
     assert_eq!(address(&scb.hfsr), 0xE000_ED2C);
     assert_eq!(address(&scb.dfsr), 0xE000_ED30);


### PR DESCRIPTION
Commit `c290aa4e` introduced `shcrs` field to `scb::RegisterBlock`. 

In CMSIS, this field is `shcsr`.

https://github.com/ARM-software/CMSIS_5/blob/5.3.0/CMSIS/Core/Include/core_cm4.h#L449

This patch changes `shcrs` to `shcsr`.

Signed-off-by: Rajiv Ranganath <rajiv.ranganath@gmail.com>