### PR TITLE
mark all assembly functions as .thumb_func

### DIFF
--- a/asm/basepri_max-cm7-r0p1.s
+++ b/asm/basepri_max-cm7-r0p1.s
@@ -1,5 +1,6 @@
   .global __basepri_max
   .syntax unified
+  .thumb_func
 __basepri_max:
   mrs r1, PRIMASK
   cpsid i

--- a/asm/basepri_max.s
+++ b/asm/basepri_max.s
@@ -1,4 +1,5 @@
   .global __basepri_max
+  .thumb_func
 __basepri_max:
   msr BASEPRI_MAX, r0
   bx lr

--- a/asm/basepri_r.s
+++ b/asm/basepri_r.s
@@ -1,4 +1,5 @@
   .global __basepri_r
+  .thumb_func
 __basepri_r:
   mrs r0, BASEPRI
   bx lr

--- a/asm/basepri_w-cm7-r0p1.s
+++ b/asm/basepri_w-cm7-r0p1.s
@@ -1,5 +1,6 @@
   .global __basepri_w
   .syntax unified
+  .thumb_func
 __basepri_w:
   mrs r1, PRIMASK
   cpsid i

--- a/asm/basepri_w.s
+++ b/asm/basepri_w.s
@@ -1,4 +1,5 @@
   .global __basepri_w
+  .thumb_func
 __basepri_w:
   msr BASEPRI, r0
   bx lr

--- a/asm/bkpt.s
+++ b/asm/bkpt.s
@@ -1,4 +1,5 @@
   .global __bkpt
+  .thumb_func
 __bkpt:
   bkpt
   bx lr

--- a/asm/control.s
+++ b/asm/control.s
@@ -1,4 +1,5 @@
   .global __control
+  .thumb_func
 __control:
   mrs r0, CONTROL
   bx lr

--- a/asm/cpsid.s
+++ b/asm/cpsid.s
@@ -1,4 +1,5 @@
   .global __cpsid
+  .thumb_func
 __cpsid:
   cpsid i
   bx lr

--- a/asm/cpsie.s
+++ b/asm/cpsie.s
@@ -1,4 +1,5 @@
   .global __cpsie
+  .thumb_func
 __cpsie:
   cpsie i
   bx lr

--- a/asm/dmb.s
+++ b/asm/dmb.s
@@ -1,4 +1,5 @@
   .global __dmb
+  .thumb_func
 __dmb:
   dmb 0xF
   bx lr

--- a/asm/dsb.s
+++ b/asm/dsb.s
@@ -1,4 +1,5 @@
   .global __dsb
+  .thumb_func
 __dsb:
   dsb 0xF
   bx lr

--- a/asm/faultmask.s
+++ b/asm/faultmask.s
@@ -1,4 +1,5 @@
   .global __faultmask
+  .thumb_func
 __faultmask:
   mrs r0, FAULTMASK
   bx lr

--- a/asm/isb.s
+++ b/asm/isb.s
@@ -1,4 +1,5 @@
   .global __isb
+  .thumb_func
 __isb:
   isb 0xF
   bx lr

--- a/asm/msp_r.s
+++ b/asm/msp_r.s
@@ -1,4 +1,5 @@
   .global __msp_r
+  .thumb_func
 __msp_r:
   mrs r0, MSP
   bx lr

--- a/asm/msp_w.s
+++ b/asm/msp_w.s
@@ -1,4 +1,5 @@
   .global __msp_w
+  .thumb_func
 __msp_w:
   msr MSP, r0
   bx lr

--- a/asm/nop.s
+++ b/asm/nop.s
@@ -1,3 +1,4 @@
   .global __nop
+  .thumb_func
 __nop:
   bx lr

--- a/asm/primask.s
+++ b/asm/primask.s
@@ -1,4 +1,5 @@
   .global __primask
+  .thumb_func
 __primask:
   mrs r0, PRIMASK
   bx lr

--- a/asm/psp_r.s
+++ b/asm/psp_r.s
@@ -1,4 +1,5 @@
   .global __psp_r
+  .thumb_func
 __psp_r:
   mrs r0, PSP
   bx lr

--- a/asm/psp_w.s
+++ b/asm/psp_w.s
@@ -1,4 +1,5 @@
   .global __psp_w
+  .thumb_func
 __psp_w:
   msr PSP, r0
   bx lr

--- a/asm/sev.s
+++ b/asm/sev.s
@@ -1,4 +1,5 @@
   .global __sev
+  .thumb_func
 __sev:
   sev
   bx lr

--- a/asm/wfe.s
+++ b/asm/wfe.s
@@ -1,4 +1,5 @@
   .global __wfe
+  .thumb_func
 __wfe:
   wfe
   bx lr

--- a/asm/wfi.s
+++ b/asm/wfi.s
@@ -1,4 +1,5 @@
   .global __wfi
+  .thumb_func
 __wfi:
   wfi
   bx lr


### PR DESCRIPTION
this works around a [LLD bug] related to interworking.

[LLD bug]: https://bugs.llvm.org/show_bug.cgi?id=38435