### PR TITLE
Always expose the VTOR register (#100)

### DIFF
--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -19,10 +19,7 @@ pub struct RegisterBlock {
     pub icsr: RW<u32>,
 
     /// Vector Table Offset (not present on Cortex-M0 variants)
-    #[cfg(not(armv6m))]
     pub vtor: RW<u32>,
-    #[cfg(armv6m)]
-    _reserved0: u32,
 
     /// Application Interrupt and Reset Control
     pub aircr: RW<u32>,


### PR DESCRIPTION
Cortex-M0+ platforms had the VTOR register hidden because of the way the
SCB chose to expose it.  This change exposes it on all platforms, with
the side effect that it will be visible on Cortex-M0 even thought the M0
SCB does not define it.