### PR TITLE
Release 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.7] - 2018-09-06
+
+### Added
+
+- `DCB::enable_trace()` and `DCB::disable_trace()`
+
 ## [v0.5.6] - 2018-08-27
 
 ### Fixed
@@ -497,7 +503,8 @@ fn main() {
 - Functions to get the vector table
 - Wrappers over miscellaneous instructions like `bkpt`
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.5.6...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.5.7...HEAD
+[v0.5.7]: https://github.com/rust-embedded/cortex-m/compare/v0.5.6...v0.5.7
 [v0.5.6]: https://github.com/rust-embedded/cortex-m/compare/v0.5.5...v0.5.6
 [v0.5.5]: https://github.com/rust-embedded/cortex-m/compare/v0.5.4...v0.5.5
 [v0.5.4]: https://github.com/rust-embedded/cortex-m/compare/v0.5.3...v0.5.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["arm", "cortex-m", "register", "peripheral"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m"
 repository = "https://github.com/japaric/cortex-m"
-version = "0.5.6"
+version = "0.5.7"
 
 [dependencies]
 aligned = "0.2.0"


### PR DESCRIPTION
As mentioned in rust-embedded/cortex-m/pull/111 (https://github.com/rust-embedded/cortex-m/pull/111#issuecomment-418896813), releasing 0.5.7 will allow the merge of japaric/stm32f103xx-hal/pull/94 which then allows japaric/stm32f103xx-hal/issues/76 to be resolved.