### PR TITLE
make `iprintln!` not depend on `iprint!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `iprintln!` no longer depends on `iprint!`. `cortex_m::iprintln!` will work
+  even if `cortex_m::iprint` has not been imported.
+
 ## [v0.5.6] - 2018-08-27
 
 ### Fixed

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,13 +13,13 @@ macro_rules! iprint {
 #[macro_export]
 macro_rules! iprintln {
     ($channel:expr) => {
-        iprint!($channel, "\n");
+        $crate::itm::write_str($channel, "\n");
     };
     ($channel:expr, $fmt:expr) => {
-        iprint!($channel, concat!($fmt, "\n"));
+        $crate::itm::write_str($channel, concat!($fmt, "\n"));
     };
     ($channel:expr, $fmt:expr, $($arg:tt)*) => {
-        iprint!($channel, concat!($fmt, "\n"), $($arg)*);
+        $crate::itm::write_fmt($channel, format_args!(concat!($fmt, "\n"), $($arg)*));
     };
 }
 


### PR DESCRIPTION
the preferred way to import macros in Rust 2018 is via `use`. If you import
`iprintln` and try to use you'll get an error if the `iprint` macro has not been
imported as well.

This commit makes `iprintln` work w/o having to import `iprint` as well.

r? @rust-embedded/cortex-m (anyone)