### PR TITLE
Add PendSV and SysTick flags

### DIFF
--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -297,6 +297,12 @@ impl VectActive {
 mod scb_consts {
     pub const SCB_CCR_IC_MASK: u32 = (1 << 17);
     pub const SCB_CCR_DC_MASK: u32 = (1 << 16);
+
+    pub const SCB_ICSR_PENDSVSET_MASK: u32 = 1 << 28;
+    pub const SCB_ICSR_PENDSVCLR_MASK: u32 = 1 << 27;
+
+    pub const SCB_ICSR_PENDSTSET_MASK: u32 = 1 << 26;
+    pub const SCB_ICSR_PENDSTCLR_MASK: u32 = 1 << 25;
 }
 
 #[cfg(not(armv6m))]
@@ -575,6 +581,56 @@ impl SCB {
 
         ::asm::dsb();
         ::asm::isb();
+    }
+
+    /// Pending SV Flag
+    ///
+    /// return     true if PendSV exception is pending, otherwise false
+    #[inline]
+    pub fn is_pendsv() -> bool {
+        // NOTE(unsafe) atomic read with no side effects
+        unsafe { (*Self::ptr()).icsr.read() & SCB_ICSR_PENDSVSET_MASK != 0 }
+    }
+
+    /// Changes PendSV exception state to pending Set Pending SV Flag
+    #[inline]
+    pub fn set_pendsv(&mut self) {
+        unsafe {
+            self.icsr.write(SCB_ICSR_PENDSVSET_MASK);
+        }
+    }
+
+    /// Removes the pending state from the PendSV exception
+    #[inline]
+    pub fn clear_pendsv(&mut self) {
+        unsafe {
+            self.icsr.write(SCB_ICSR_PENDSVCLR_MASK);
+        }
+    }
+
+    /// ICSR SysTick flag
+    ///
+    /// return      true if SysTick exception is pending, otherwise false
+    #[inline]
+    pub fn is_systick_pending() -> bool {
+        // NOTE(unsafe) atomic read with no side effects
+        unsafe { (*Self::ptr()).icsr.read() & SCB_ICSR_PENDSTSET_MASK != 0 }
+    }
+
+    /// Changes SysTick exception state to pending
+    #[inline]
+    pub fn set_systick_pending(&mut self) {
+        unsafe {
+            self.icsr.write(SCB_ICSR_PENDSTSET_MASK);
+        }
+    }
+
+    /// Removes the pending state from the SysTick exception
+    #[inline]
+    pub fn clear_systick_pending(&mut self) {
+        unsafe {
+            self.icsr.write(SCB_ICSR_PENDSTCLR_MASK);
+        }
     }
 }
 


### PR DESCRIPTION
CMSIS core headers contains SCB_ICSR_PENDSVSET_*** and SCB_ICSR_PENDSTSET_*** definitions, which I need in my projects. In CMSIS it is used to check, set and clear this flags (rtx_core_cm.h and os_systick.c).

I suggest adding it to scb.rs. I put initial commit, but I need help to add compiler barriers where its are needed.

For details, see CMSIS:
[CMSIS_5/CMSIS/Core/Include/core_cm3.h](https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/Core/Include/core_cm3.h)  (or other core_cm{X}.h)
[CMSIS_5/CMSIS/RTOS2/RTX/Source/rtx_core_cm.h)](https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/RTOS2/RTX/Source/rtx_core_cm.h)
[CMSIS_5/CMSIS/RTOS2/Source/os_systick.c)](https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/RTOS2/Source/os_systick.c)
