### PR TITLE
add high level API to set priority of system handlers

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,6 +1,10 @@
 set -euxo pipefail
 
 main() {
+    if [ $TRAVIS_RUST_VERSION = nightly ]; then
+        export RUSTFLAGS="-D warnings"
+    fi
+
     cargo check --target $TARGET
 
     if [ $TRAVIS_RUST_VERSION = nightly ]; then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@
 
 #![cfg_attr(feature = "inline-asm", feature(asm))]
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![no_std]
 
 extern crate aligned;

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -77,7 +77,6 @@
 
 // TODO stand-alone registers: ICTR, ACTLR and STIR
 
-#![allow(private_no_mangle_statics)]
 
 use core::marker::PhantomData;
 use core::ops;

--- a/src/peripheral/nvic.rs
+++ b/src/peripheral/nvic.rs
@@ -177,6 +177,11 @@ impl NVIC {
     ///
     /// On ARMv6-M, updating an interrupt priority requires a read-modify-write operation. On
     /// ARMv7-M, the operation is performed in a single atomic write operation.
+    ///
+    /// # Unsafety
+    ///
+    /// Changing priority levels can break priority-based critical sections (see
+    /// [`register::basepri`](../register/basepri/index.html)) and compromise memory safety.
     pub unsafe fn set_priority<I>(&mut self, interrupt: I, prio: u8)
     where
         I: Nr,

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -669,3 +669,116 @@ impl SCB {
         }
     }
 }
+
+/// System handlers, exceptions with configurable priority
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SystemHandler {
+    // NonMaskableInt, // priority is fixed
+    // HardFault, // priority is fixed
+    /// Memory management interrupt (not present on Cortex-M0 variants)
+    #[cfg(not(armv6m))]
+    MemoryManagement,
+
+    /// Bus fault interrupt (not present on Cortex-M0 variants)
+    #[cfg(not(armv6m))]
+    BusFault,
+
+    /// Usage fault interrupt (not present on Cortex-M0 variants)
+    #[cfg(not(armv6m))]
+    UsageFault,
+
+    /// Secure fault interrupt (only on ARMv8-M)
+    #[cfg(any(armv8m, target_arch = "x86_64"))]
+    SecureFault,
+
+    /// SV call interrupt
+    SVCall,
+
+    // #[cfg(not(armv6m))]
+    // DebugMonitor, // unclear whether this has configurable priority
+    /// Pend SV interrupt
+    PendSV,
+
+    /// System Tick interrupt
+    SysTick,
+
+    // Make this enum extensible
+    #[doc(hidden)]
+    __DO_NOT_MATCH_AGAINST_THIS_VARIANT__,
+}
+
+impl SystemHandler {
+    fn index(&self) -> u8 {
+        match *self {
+            #[cfg(not(armv6m))]
+            SystemHandler::MemoryManagement => 4,
+            #[cfg(not(armv6m))]
+            SystemHandler::BusFault => 5,
+            #[cfg(not(armv6m))]
+            SystemHandler::UsageFault => 6,
+            #[cfg(any(armv8m, target_arch = "x86_64"))]
+            SystemHandler::SecureFault => 7,
+            SystemHandler::SVCall => 11,
+            SystemHandler::PendSV => 14,
+            SystemHandler::SysTick => 15,
+            SystemHandler::__DO_NOT_MATCH_AGAINST_THIS_VARIANT__ => unreachable!(),
+        }
+    }
+}
+
+impl SCB {
+    /// Returns the hardware priority of `system_handler`
+    ///
+    /// *NOTE*: Hardware priority does not exactly match logical priority levels. See
+    /// [`NVIC.get_priority`](struct.NVIC.html#method.get_priority) for more details.
+    pub fn get_priority(system_handler: SystemHandler) -> u8 {
+        let index = system_handler.index();
+
+        #[cfg(not(armv6m))]
+        {
+            // NOTE(unsafe) atomic read with no side effects
+            unsafe { (*Self::ptr()).shpr[usize::from(index - 4)].read() }
+        }
+
+        #[cfg(armv6m)]
+        {
+            // NOTE(unsafe) atomic read with no side effects
+            let shpr = unsafe { (*Self::ptr()).shpr[usize::from((index - 8) / 4)].read() };
+            let prio = (shpr >> (index % 4)) & 0x000000ff;
+            prio as u8
+        }
+    }
+
+    /// Sets the hardware priority of `system_handler` to `prio`
+    ///
+    /// *NOTE*: Hardware priority does not exactly match logical priority levels. See
+    /// [`NVIC.get_priority`](struct.NVIC.html#method.get_priority) for more details.
+    ///
+    /// On ARMv6-M, updating a system handler priority requires a read-modify-write operation. On
+    /// ARMv7-M, the operation is performed in a single, atomic write operation.
+    ///
+    /// # Unsafety
+    ///
+    /// Changing priority levels can break priority-based critical sections (see
+    /// [`register::basepri`](../register/basepri/index.html)) and compromise memory safety.
+    pub unsafe fn set_priority(&mut self, system_handler: SystemHandler, prio: u8) {
+        let index = system_handler.index();
+
+        #[cfg(not(armv6m))]
+        {
+            self.shpr[usize::from(index - 4)].write(prio)
+        }
+
+        #[cfg(armv6m)]
+        {
+            self.shpr[usize::from((index - 8) / 4)].modify(|value| {
+                let shift = index % 4;
+                let mask = 0x000000ff << shift;
+                let prio = u32::from(prio) << shift;
+
+                (value & !mask) | prio
+            });
+        }
+    }
+}

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -695,8 +695,10 @@ pub enum SystemHandler {
     /// SV call interrupt
     SVCall,
 
-    // #[cfg(not(armv6m))]
-    // DebugMonitor, // unclear whether this has configurable priority
+    /// Debug monitor interrupt (not present on Cortex-M0 variants)
+    #[cfg(not(armv6m))]
+    DebugMonitor,
+
     /// Pend SV interrupt
     PendSV,
 
@@ -720,6 +722,8 @@ impl SystemHandler {
             #[cfg(any(armv8m, target_arch = "x86_64"))]
             SystemHandler::SecureFault => 7,
             SystemHandler::SVCall => 11,
+            #[cfg(not(armv6m))]
+            SystemHandler::DebugMonitor => 12,
             SystemHandler::PendSV => 14,
             SystemHandler::SysTick => 15,
             SystemHandler::__DO_NOT_MATCH_AGAINST_THIS_VARIANT__ => unreachable!(),

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -745,7 +745,7 @@ impl SCB {
         {
             // NOTE(unsafe) atomic read with no side effects
             let shpr = unsafe { (*Self::ptr()).shpr[usize::from((index - 8) / 4)].read() };
-            let prio = (shpr >> (index % 4)) & 0x000000ff;
+            let prio = (shpr >> (8 * (index % 4))) & 0x000000ff;
             prio as u8
         }
     }
@@ -773,7 +773,7 @@ impl SCB {
         #[cfg(armv6m)]
         {
             self.shpr[usize::from((index - 8) / 4)].modify(|value| {
-                let shift = index % 4;
+                let shift = 8 * (index % 4);
                 let mask = 0x000000ff << shift;
                 let prio = u32::from(prio) << shift;
 

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -704,10 +704,6 @@ pub enum SystemHandler {
 
     /// System Tick interrupt
     SysTick,
-
-    // Make this enum extensible
-    #[doc(hidden)]
-    __DO_NOT_MATCH_AGAINST_THIS_VARIANT__,
 }
 
 impl SystemHandler {
@@ -726,7 +722,6 @@ impl SystemHandler {
             SystemHandler::DebugMonitor => 12,
             SystemHandler::PendSV => 14,
             SystemHandler::SysTick => 15,
-            SystemHandler::__DO_NOT_MATCH_AGAINST_THIS_VARIANT__ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
needed for cortex-m-rtfm v0.4.x (it makes my life easier / it makes it easier to
support ARMv6-M)

r? @rust-embedded/cortex-m (anyone)