### PR TITLE
Cortex M0(+) DWT fixes

### DIFF
--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -1,6 +1,8 @@
 //! Data Watchpoint and Trace unit
 
-use volatile_register::{RO, RW, WO};
+#[cfg(not(armv6m))]
+use volatile_register::WO;
+use volatile_register::{RO, RW};
 
 use peripheral::DWT;
 

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -10,25 +10,41 @@ pub struct RegisterBlock {
     /// Control
     pub ctrl: RW<u32>,
     /// Cycle Count
+    #[cfg(not(armv6m))]
     pub cyccnt: RW<u32>,
     /// CPI Count
+    #[cfg(not(armv6m))]
     pub cpicnt: RW<u32>,
     /// Exception Overhead Count
+    #[cfg(not(armv6m))]
     pub exccnt: RW<u32>,
     /// Sleep Count
+    #[cfg(not(armv6m))]
     pub sleepcnt: RW<u32>,
     /// LSU Count
+    #[cfg(not(armv6m))]
     pub lsucnt: RW<u32>,
     /// Folded-instruction Count
+    #[cfg(not(armv6m))]
     pub foldcnt: RW<u32>,
+    /// Cortex-M0(+) does not have  these parts
+    #[cfg(armv6m)]
+    reserved: [u32; 6],
     /// Program Counter Sample
     pub pcsr: RO<u32>,
     /// Comparators
+    #[cfg(armv6m)]
+    pub c: [Comparator; 2],
+    #[cfg(not(armv6m))]
+    /// Comparators
     pub c: [Comparator; 16],
+    #[cfg(not(armv6m))]
     reserved: [u32; 932],
     /// Lock Access
+    #[cfg(not(armv6m))]
     pub lar: WO<u32>,
     /// Lock Status
+    #[cfg(not(armv6m))]
     pub lsr: RO<u32>,
 }
 
@@ -46,11 +62,13 @@ pub struct Comparator {
 
 impl DWT {
     /// Enables the cycle counter
+    #[cfg(not(armv6m))]
     pub fn enable_cycle_counter(&mut self) {
         unsafe { self.ctrl.modify(|r| r | 1) }
     }
 
     /// Returns the current clock cycle count
+    #[cfg(not(armv6m))]
     pub fn get_cycle_count() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
         unsafe { (*Self::ptr()).cyccnt.read() }

--- a/src/peripheral/test.rs
+++ b/src/peripheral/test.rs
@@ -29,11 +29,17 @@ fn dwt() {
     let dwt = unsafe { &*::peripheral::DWT::ptr() };
 
     assert_eq!(address(&dwt.ctrl), 0xE000_1000);
+    #[cfg(not(armv6m))]
     assert_eq!(address(&dwt.cyccnt), 0xE000_1004);
+    #[cfg(not(armv6m))]
     assert_eq!(address(&dwt.cpicnt), 0xE000_1008);
+    #[cfg(not(armv6m))]
     assert_eq!(address(&dwt.exccnt), 0xE000_100C);
+    #[cfg(not(armv6m))]
     assert_eq!(address(&dwt.sleepcnt), 0xE000_1010);
+    #[cfg(not(armv6m))]
     assert_eq!(address(&dwt.lsucnt), 0xE000_1014);
+    #[cfg(not(armv6m))]
     assert_eq!(address(&dwt.foldcnt), 0xE000_1018);
     assert_eq!(address(&dwt.pcsr), 0xE000_101C);
     assert_eq!(address(&dwt.c[0].comp), 0xE000_1020);
@@ -42,7 +48,9 @@ fn dwt() {
     assert_eq!(address(&dwt.c[1].comp), 0xE000_1030);
     assert_eq!(address(&dwt.c[1].mask), 0xE000_1034);
     assert_eq!(address(&dwt.c[1].function), 0xE000_1038);
+    #[cfg(not(armv6m))]
     assert_eq!(address(&dwt.lar), 0xE000_1FB0);
+    #[cfg(not(armv6m))]
     assert_eq!(address(&dwt.lsr), 0xE000_1FB4);
 }
 


### PR DESCRIPTION
The current DWT setup has a lot of registers that are not available in Cortex-M0(+), fixes are added here.

