### PR TITLE
add thumbv8m.base to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ matrix:
       rust: nightly
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
+    - env: TARGET=thumbv8m.base-none-eabi
+      rust: nightly
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
+
 before_install: set -e
 
 install:


### PR DESCRIPTION
baseline support was added in https://github.com/rust-embedded/cortex-m/pull/123 but it wasn't added to the travis config