### PR TITLE
scb: add static version of system_reset as sys_reset

### DIFF
--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -619,6 +619,27 @@ impl SCB {
             ::asm::nop(); // avoid rust-lang/rust#28728
         }
     }
+
+    /// Initiate a system reset request to reset the MCU
+    ///
+    /// Static version of [`SCB::system_reset`].
+    pub fn system_reset2() -> ! {
+        ::asm::dsb();
+        unsafe {
+            (*Self::ptr()).aircr.modify(
+                |r| {
+                    SCB_AIRCR_VECTKEY | // otherwise the write is ignored
+            r & SCB_AIRCR_PRIGROUP_MASK | // keep priority group unchanged
+            SCB_AIRCR_SYSRESETREQ
+                }, // set the bit
+            )
+        };
+        ::asm::dsb();
+        loop {
+            // wait for the reset
+            ::asm::nop(); // avoid rust-lang/rust#28728
+        }
+    }
 }
 
 const SCB_ICSR_PENDSVSET: u32 = 1 << 28;

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -602,6 +602,7 @@ const SCB_AIRCR_SYSRESETREQ: u32 = 1 << 2;
 
 impl SCB {
     /// Initiate a system reset request to reset the MCU
+    #[deprecated(since = "0.6.1", note = "Use `SCB::sys_reset`")]
     pub fn system_reset(&mut self) -> ! {
         ::asm::dsb();
         unsafe {
@@ -621,9 +622,7 @@ impl SCB {
     }
 
     /// Initiate a system reset request to reset the MCU
-    ///
-    /// Static version of [`SCB::system_reset`].
-    pub fn system_reset2() -> ! {
+    pub fn sys_reset() -> ! {
         ::asm::dsb();
         unsafe {
             (*Self::ptr()).aircr.modify(


### PR DESCRIPTION
As suggested in https://github.com/ah-/anne-key/pull/94. I branched this off v0.5.8 to verify the function in that PR, and against rtfm v0.3 in https://github.com/hdhoang/anne-key/commit/d6fb831cbbb46bc10a6184b78bf13e00245234d6

I have cloned the body of `system_reset`, do you think we should call one from the other (e.g. ignoring `self` in `system_reset`, or stealing `Peripherals` in `system_reset2`)?