### PR TITLE
Cargo.toml: Add `links = "cortex-m"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/japaric/cortex-m"
 version = "0.6.0"
+links = "cortex-m"  # prevent multiple versions of this crate to be linked together
 
 [dependencies]
 aligned = "0.3.1"


### PR DESCRIPTION
This prevents linking multiple versions of `cortex-m` together, which would be
unsound. Currently it uses a `#[no_mangle]` static for this, which isn't always
reliable.

Fixes #137