### PR TITLE
Prepare for 0.5.10 which exports features to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.5.9"
+version = "0.5.10"
 
 [dependencies]
 aligned = "0.2.0"
@@ -17,6 +17,6 @@ volatile-register = "0.2.0"
 cortex_m_0_6 = { package = "cortex-m", version = "0.6.0" }
 
 [features]
-cm7-r0p1 = []
-const-fn = ["bare-metal/const-fn"]
-inline-asm = []
+cm7-r0p1 = ["cortex_m_0_6/cm7-r0p1"]
+const-fn = ["bare-metal/const-fn", "cortex_m_0_6/const-fn"]
+inline-asm = ["cortex_m_0_6/inline-asm"]


### PR DESCRIPTION
@japaric noticed that 0.5.9 does not set its own features on its dependency on cortex-m 0.6.0, which means for example enabling `inline-asm` on 0.5.9 would _not_ cause inline assembly to be generated, because 0.5.9 re-exports 0.6.0's `asm` module, which wouldn't necessarily have had the feature enabled.

This PR updates 0.5.10's Cargo.toml to re-export those features too.

I've tested this continues to work as before (in fact you can successfully build an application using 0.5.9 and 0.5.10 and 0.6.0), and also tested that inline asm generation is working correctly (when the application depends on 0.5.10 with inline-asm feature, calls to cortex_m::asm result in inline asm).