### PR TITLE
scb: add static version of `set_sleepdeep` and `clear_sleepdeep` as `set_sleep_deep` and `clear_sleep_deep` respectively.

### DIFF
--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -582,16 +582,32 @@ const SCB_SCR_SLEEPDEEP: u32 = 0x1 << 2;
 
 impl SCB {
     /// Set the SLEEPDEEP bit in the SCR register
+    #[deprecated(since = "0.6.1", note = "Use `SCB::set_sleep_deep`")]
     pub fn set_sleepdeep(&mut self) {
         unsafe {
             self.scr.modify(|scr| scr | SCB_SCR_SLEEPDEEP);
         }
     }
 
+    /// Set the SLEEPDEEP bit in the SCR register
+    pub fn set_sleep_deep() {
+        unsafe {
+            (*Self::ptr()).scr.modify(|scr| scr | SCB_SCR_SLEEPDEEP);
+        }
+    }
+
     /// Clear the SLEEPDEEP bit in the SCR register
+    #[deprecated(since = "0.6.1", note = "Use `SCB::clear_sleep_deep`")]
     pub fn clear_sleepdeep(&mut self) {
         unsafe {
             self.scr.modify(|scr| scr & !SCB_SCR_SLEEPDEEP);
+        }
+    }
+
+    /// Clear the SLEEPDEEP bit in the SCR register
+    pub fn clear_sleep_deep() {
+        unsafe {
+            (*Self::ptr()).scr.modify(|scr| scr & !SCB_SCR_SLEEPDEEP);
         }
     }
 }


### PR DESCRIPTION
Makes a change similar to the one made here https://github.com/rust-embedded/cortex-m/pull/138, but for `set_sleepdeep`/`clear_sleepdeep` method pair.

Didn't find any better alternative names as `set_sleep_deep` and `clear_sleep_deep` respectively, happy to hear other suggestions.

Fixes https://github.com/japaric/cortex-m-rtfm/issues/165.