### PR TITLE
Remove debug_assert from Peripherals::steal

### DIFF
--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -167,8 +167,6 @@ impl Peripherals {
 
     /// Unchecked version of `Peripherals::take`
     pub unsafe fn steal() -> Self {
-        debug_assert!(!CORE_PERIPHERALS);
-
         CORE_PERIPHERALS = true;
 
         Peripherals {


### PR DESCRIPTION
This is the same change as https://github.com/rust-embedded/svd2rust/pull/238, except for the one bit that isn't generated by svd2rust. There was a decent amount of discussion about this over at that issue, and to me it makes sense to change this here as well. It's `unsafe`, so let the user decide if they want to use it.