### PR TITLE
Define MSRV to be 1.31.0 and unconditionally use const-fn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,26 @@ matrix:
       rust: stable
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
+    # MSRV
+    - env: TARGET=thumbv6m-none-eabi
+      rust: 1.31.0
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
+
+    # MSRV
+    - env: TARGET=thumbv7m-none-eabi
+      rust: 1.31.0
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
+
+    # MSRV
+    - env: TARGET=thumbv7em-none-eabi
+      rust: 1.31.0
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
+
+    # MSRV
+    - env: TARGET=thumbv7em-none-eabihf
+      rust: 1.31.0
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
+
     - env: TARGET=thumbv6m-none-eabi
       rust: nightly
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ links = "cortex-m"  # prevent multiple versions of this crate to be linked toget
 
 [dependencies]
 aligned = "0.3.1"
-bare-metal = "0.2.0"
+bare-metal = { version = "0.2.0", features = ["const-fn"] }
 volatile-register = "0.2.0"
 
 [features]
 cm7-r0p1 = []
-const-fn = ["bare-metal/const-fn"]
 inline-asm = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 repository = "https://github.com/japaric/cortex-m"
 version = "0.6.0"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
+edition = "2018"
 
 [dependencies]
 aligned = "0.3.1"
@@ -20,5 +21,6 @@ bare-metal = { version = "0.2.0", features = ["const-fn"] }
 volatile-register = "0.2.0"
 
 [features]
+const-fn = []
 cm7-r0p1 = []
 inline-asm = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 repository = "https://github.com/japaric/cortex-m"
 version = "0.6.0"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
-edition = "2018"
 
 [dependencies]
 aligned = "0.3.1"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -8,7 +8,7 @@ main() {
     cargo check --target $TARGET
 
     if [ $TRAVIS_RUST_VERSION = nightly ]; then
-        cargo check --target $TARGET --features 'const-fn inline-asm'
+        cargo check --target $TARGET --features 'inline-asm'
     fi
 
     case $TARGET in
@@ -16,7 +16,7 @@ main() {
             cargo check --target $TARGET --features cm7-r0p1
 
             if [ $TRAVIS_RUST_VERSION = nightly ]; then
-                cargo check --target $TARGET --features 'cm7-r0p1 const-fn inline-asm'
+                cargo check --target $TARGET --features 'cm7-r0p1 inline-asm'
             fi
             ;;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,10 @@
 //!
 //! The disadvantage is that `inline-asm` requires a nightly toolchain.
 //!
-//! ## `const-fn`
+//! # Minimum Supported Rust Version (MSRV)
 //!
-//! Enabling this feature turns the `Mutex.new` constructor into a `const fn`.
-//!
-//! This feature requires a nightly toolchain.
+//! This crate is guaranteed to compile on stable Rust 1.31 and up. It *might*
+//! compile with older versions but that may change in any new patch release.
 
 #![cfg_attr(feature = "inline-asm", feature(asm))]
 #![deny(missing_docs)]


### PR DESCRIPTION
As per https://github.com/rust-embedded/wg/blob/master/ops/msrv.md we should have a defined MSRV for this crate. This PR proposes setting it to 1.31 to allow use of `const-fn` from bare-metal by default, and updates `Cargo.toml` accordingly. It also sets the edition to 2018, permitted by an MSRV of 1.31.

Since this PR _introduces_ an MSRV I propose it not requiring a semver bump, and we instead would look to release this change as `0.6.1`.

Closes #153.