### PR TITLE
fix changelog link for v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -562,7 +562,7 @@ fn main() {
 - Wrappers over miscellaneous instructions like `bkpt`
 
 [Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.6.1...HEAD
-[v0.6.0]: https://github.com/rust-embedded/cortex-m/compare/v0.6.0...v0.6.1
+[v0.6.1]: https://github.com/rust-embedded/cortex-m/compare/v0.6.0...v0.6.1
 [v0.6.0]: https://github.com/rust-embedded/cortex-m/compare/v0.5.8...v0.6.0
 [v0.5.8]: https://github.com/rust-embedded/cortex-m/compare/v0.5.7...v0.5.8
 [v0.5.7]: https://github.com/rust-embedded/cortex-m/compare/v0.5.6...v0.5.7


### PR DESCRIPTION
The v0.6.1 link is broken and v0.6.0 links to v0.6.1 changes. Fix the typo to fix that