### PR TITLE
Add an unsafe fn `SCB::steal`

### DIFF
--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -429,6 +429,18 @@ pub struct SCB {
 unsafe impl Send for SCB {}
 
 impl SCB {
+    /// Unsafely obtains an `SCB` instance from nothing.
+    /// 
+    /// # Safety
+    /// 
+    /// This is only safe to use when the returned `SCB` instance is used
+    /// correctly without conflicting with any other existing `SCB` instances.
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+
     /// Returns a pointer to the register block
     pub fn ptr() -> *const scb::RegisterBlock {
         0xE000_ED04 as *const _

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -433,8 +433,8 @@ impl SCB {
     /// 
     /// # Safety
     /// 
-    /// This is only safe to use when the returned `SCB` instance is used
-    /// correctly without conflicting with any other existing `SCB` instances.
+    /// The caller has to ensure that all SCB access is synchronized across all
+    /// `SCB` instances to avoid race conditions.
     pub unsafe fn steal() -> Self {
         Self {
             _marker: PhantomData,


### PR DESCRIPTION
This allows safely creating an `SCB` instance from nothing, which is required when combining rtfm 0.4.x with APIs that make use of `SCB`/`&mut SCB` (rtfm retains ownership of the SCB).

Before, it was already possible to unsafely access the SCB register block via `SCB::ptr()`. However, it was impossible to obtain an `SCB` instance itself.