### PR TITLE
Add `#[inline]` to lots of trivial functions.

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -57,6 +57,7 @@ pub unsafe fn enable() {
 /// Execute closure `f` in an interrupt-free context.
 ///
 /// This as also known as a "critical section".
+#[inline]
 pub fn free<F, R>(f: F) -> R
 where
     F: FnOnce(&CriticalSection) -> R,

--- a/src/itm.rs
+++ b/src/itm.rs
@@ -21,6 +21,7 @@ unsafe fn write_words(stim: &mut Stim, bytes: &[u32]) {
 struct Port<'p>(&'p mut Stim);
 
 impl<'p> fmt::Write for Port<'p> {
+    #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         write_all(self.0, s.as_bytes());
         Ok(())
@@ -126,6 +127,7 @@ pub fn write_aligned(port: &mut Stim, buffer: &Aligned<A4, [u8]>) {
 }
 
 /// Writes `fmt::Arguments` to the ITM `port`
+#[inline]
 pub fn write_fmt(port: &mut Stim, args: fmt::Arguments) {
     use core::fmt::Write;
 
@@ -133,6 +135,7 @@ pub fn write_fmt(port: &mut Stim, args: fmt::Arguments) {
 }
 
 /// Writes a string to the ITM `port`
+#[inline]
 pub fn write_str(port: &mut Stim, string: &str) {
     write_all(port, string.as_bytes())
 }

--- a/src/peripheral/cpuid.rs
+++ b/src/peripheral/cpuid.rs
@@ -82,6 +82,7 @@ impl CPUID {
     /// * `ind`: select instruction cache or data/unified cache
     ///
     /// `level` is masked to be between 0 and 7.
+    #[inline]
     pub fn select_cache(&mut self, level: u8, ind: CsselrCacheType) {
         const CSSELR_IND_POS: u32 = 0;
         const CSSELR_IND_MASK: u32 = 1 << CSSELR_IND_POS;
@@ -97,6 +98,7 @@ impl CPUID {
     }
 
     /// Returns the number of sets and ways in the selected cache
+    #[inline]
     pub fn cache_num_sets_ways(&mut self, level: u8, ind: CsselrCacheType) -> (u16, u16) {
         const CCSIDR_NUMSETS_POS: u32 = 13;
         const CCSIDR_NUMSETS_MASK: u32 = 0x7FFF << CCSIDR_NUMSETS_POS;

--- a/src/peripheral/dcb.rs
+++ b/src/peripheral/dcb.rs
@@ -25,6 +25,7 @@ impl DCB {
     /// `peripheral::DWT` cycle counter to work properly.
     /// As by STM documentation, this flag is not reset on
     /// soft-reset, only on power reset.
+    #[inline]
     pub fn enable_trace(&mut self) {
         // set bit 24 / TRCENA
         unsafe {
@@ -33,6 +34,7 @@ impl DCB {
     }
 
     /// Disables TRACE. See `DCB::enable_trace()` for more details
+    #[inline]
     pub fn disable_trace(&mut self) {
         // unset bit 24 / TRCENA
         unsafe {
@@ -47,6 +49,7 @@ impl DCB {
     /// on Cortex-M0 devices. Per the ARM v6-M Architecture Reference Manual, "Access to the DHCSR
     /// from software running on the processor is IMPLEMENTATION DEFINED". Indeed, from the
     /// [Cortex-M0+ r0p1 Technical Reference Manual](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0484c/BABJHEIG.html), "Note Software cannot access the debug registers."
+    #[inline]
     pub fn is_debugger_attached() -> bool {
         unsafe {
             // do an 8-bit read of the 32-bit DHCSR register, and get the LSB

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -65,12 +65,14 @@ pub struct Comparator {
 impl DWT {
     /// Enables the cycle counter
     #[cfg(not(armv6m))]
+    #[inline]
     pub fn enable_cycle_counter(&mut self) {
         unsafe { self.ctrl.modify(|r| r | 1) }
     }
 
     /// Returns the current clock cycle count
     #[cfg(not(armv6m))]
+    #[inline]
     pub fn get_cycle_count() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
         unsafe { (*Self::ptr()).cyccnt.read() }

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -82,6 +82,7 @@ impl DWT {
     ///
     /// Some devices, like the STM32F7, software lock the DWT after a power cycle.
     #[cfg(not(armv6m))]
+    #[inline]
     pub fn unlock() {
         // NOTE(unsafe) atomic write to a stateless, write-only register
         unsafe { (*Self::ptr()).lar.write(0xC5ACCE55) }

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -35,21 +35,25 @@ pub struct Stim {
 
 impl Stim {
     /// Writes an `u8` payload into the stimulus port
+    #[inline]
     pub fn write_u8(&mut self, value: u8) {
         unsafe { ptr::write_volatile(self.register.get() as *mut u8, value) }
     }
 
     /// Writes an `u16` payload into the stimulus port
+    #[inline]
     pub fn write_u16(&mut self, value: u16) {
         unsafe { ptr::write_volatile(self.register.get() as *mut u16, value) }
     }
 
     /// Writes an `u32` payload into the stimulus port
+    #[inline]
     pub fn write_u32(&mut self, value: u32) {
         unsafe { ptr::write_volatile(self.register.get(), value) }
     }
 
     /// Returns `true` if the stimulus port is ready to accept more data
+    #[inline]
     pub fn is_fifo_ready(&self) -> bool {
         unsafe { ptr::read_volatile(self.register.get()) == 1 }
     }

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -158,6 +158,7 @@ impl Peripherals {
     }
 
     /// Unchecked version of `Peripherals::take`
+    #[inline]
     pub unsafe fn steal() -> Self {
         CORE_PERIPHERALS = true;
 
@@ -211,6 +212,7 @@ unsafe impl Send for CBP {}
 
 #[cfg(not(armv6m))]
 impl CBP {
+    #[inline(always)]
     pub(crate) unsafe fn new() -> Self {
         CBP {
             _marker: PhantomData,
@@ -218,6 +220,7 @@ impl CBP {
     }
 
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const self::cbp::RegisterBlock {
         0xE000_EF50 as *const _
     }
@@ -227,6 +230,7 @@ impl CBP {
 impl ops::Deref for CBP {
     type Target = self::cbp::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -241,6 +245,7 @@ unsafe impl Send for CPUID {}
 
 impl CPUID {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const self::cpuid::RegisterBlock {
         0xE000_ED00 as *const _
     }
@@ -249,6 +254,7 @@ impl CPUID {
 impl ops::Deref for CPUID {
     type Target = self::cpuid::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -263,6 +269,7 @@ unsafe impl Send for DCB {}
 
 impl DCB {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const dcb::RegisterBlock {
         0xE000_EDF0 as *const _
     }
@@ -271,6 +278,7 @@ impl DCB {
 impl ops::Deref for DCB {
     type Target = self::dcb::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*DCB::ptr() }
     }
@@ -285,6 +293,7 @@ unsafe impl Send for DWT {}
 
 impl DWT {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const dwt::RegisterBlock {
         0xE000_1000 as *const _
     }
@@ -293,6 +302,7 @@ impl DWT {
 impl ops::Deref for DWT {
     type Target = self::dwt::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -308,6 +318,7 @@ unsafe impl Send for FPB {}
 #[cfg(not(armv6m))]
 impl FPB {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const fpb::RegisterBlock {
         0xE000_2000 as *const _
     }
@@ -317,6 +328,7 @@ impl FPB {
 impl ops::Deref for FPB {
     type Target = self::fpb::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -332,6 +344,7 @@ unsafe impl Send for FPU {}
 #[cfg(any(has_fpu, target_arch = "x86_64"))]
 impl FPU {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const fpu::RegisterBlock {
         0xE000_EF30 as *const _
     }
@@ -341,6 +354,7 @@ impl FPU {
 impl ops::Deref for FPU {
     type Target = self::fpu::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -356,6 +370,7 @@ unsafe impl Send for ITM {}
 #[cfg(not(armv6m))]
 impl ITM {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *mut itm::RegisterBlock {
         0xE000_0000 as *mut _
     }
@@ -365,6 +380,7 @@ impl ITM {
 impl ops::Deref for ITM {
     type Target = self::itm::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -372,6 +388,7 @@ impl ops::Deref for ITM {
 
 #[cfg(not(armv6m))]
 impl ops::DerefMut for ITM {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *Self::ptr() }
     }
@@ -386,6 +403,7 @@ unsafe impl Send for MPU {}
 
 impl MPU {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const mpu::RegisterBlock {
         0xE000_ED90 as *const _
     }
@@ -394,6 +412,7 @@ impl MPU {
 impl ops::Deref for MPU {
     type Target = self::mpu::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -408,6 +427,7 @@ unsafe impl Send for NVIC {}
 
 impl NVIC {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const nvic::RegisterBlock {
         0xE000_E100 as *const _
     }
@@ -416,6 +436,7 @@ impl NVIC {
 impl ops::Deref for NVIC {
     type Target = self::nvic::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -430,6 +451,7 @@ unsafe impl Send for SCB {}
 
 impl SCB {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const scb::RegisterBlock {
         0xE000_ED04 as *const _
     }
@@ -438,6 +460,7 @@ impl SCB {
 impl ops::Deref for SCB {
     type Target = self::scb::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -452,6 +475,7 @@ unsafe impl Send for SYST {}
 
 impl SYST {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const syst::RegisterBlock {
         0xE000_E010 as *const _
     }
@@ -460,6 +484,7 @@ impl SYST {
 impl ops::Deref for SYST {
     type Target = self::syst::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }
@@ -475,6 +500,7 @@ unsafe impl Send for TPIU {}
 #[cfg(not(armv6m))]
 impl TPIU {
     /// Returns a pointer to the register block
+    #[inline(always)]
     pub fn ptr() -> *const tpiu::RegisterBlock {
         0xE004_0000 as *const _
     }
@@ -484,6 +510,7 @@ impl TPIU {
 impl ops::Deref for TPIU {
     type Target = self::tpiu::RegisterBlock;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::ptr() }
     }

--- a/src/peripheral/nvic.rs
+++ b/src/peripheral/nvic.rs
@@ -83,6 +83,7 @@ impl NVIC {
     /// `set_pending`.
     ///
     /// This method is not available on ARMv6-M chips.
+    #[inline]
     pub fn request<I>(&mut self, interrupt: I)
     where
         I: Nr,
@@ -96,6 +97,7 @@ impl NVIC {
 
     /// Clears `interrupt`'s pending state
     #[deprecated(since = "0.5.8", note = "Use `NVIC::unpend`")]
+    #[inline]
     pub fn clear_pending<I>(&mut self, interrupt: I)
     where
         I: Nr,
@@ -104,6 +106,7 @@ impl NVIC {
     }
 
     /// Disables `interrupt`
+    #[inline]
     pub fn mask<I>(interrupt: I)
     where
         I: Nr,
@@ -116,6 +119,7 @@ impl NVIC {
     /// Enables `interrupt`
     ///
     /// This function is `unsafe` because it can break mask-based critical sections
+    #[inline]
     pub unsafe fn unmask<I>(interrupt: I)
     where
         I: Nr,
@@ -127,6 +131,7 @@ impl NVIC {
 
     /// Disables `interrupt`
     #[deprecated(since = "0.6.1", note = "Use `NVIC::mask`")]
+    #[inline]
     pub fn disable<I>(&mut self, interrupt: I)
     where
         I: Nr,
@@ -137,6 +142,7 @@ impl NVIC {
     /// **WARNING** This method is a soundness hole in the API; it should actually be an `unsafe`
     /// function. Use `NVIC::unmask` which has the right unsafety.
     #[deprecated(since = "0.6.1", note = "Use `NVIC::unmask`")]
+    #[inline]
     pub fn enable<I>(&mut self, interrupt: I)
     where
         I: Nr,
@@ -149,6 +155,7 @@ impl NVIC {
     /// *NOTE* NVIC encodes priority in the highest bits of a byte so values like `1` and `2` map
     /// to the same priority. Also for NVIC priorities, a lower value (e.g. `16`) has higher
     /// priority (urgency) than a larger value (e.g. `32`).
+    #[inline]
     pub fn get_priority<I>(interrupt: I) -> u8
     where
         I: Nr,
@@ -171,6 +178,7 @@ impl NVIC {
 
     /// Is `interrupt` active or pre-empted and stacked
     #[cfg(not(armv6m))]
+    #[inline]
     pub fn is_active<I>(interrupt: I) -> bool
     where
         I: Nr,
@@ -183,6 +191,7 @@ impl NVIC {
     }
 
     /// Checks if `interrupt` is enabled
+    #[inline]
     pub fn is_enabled<I>(interrupt: I) -> bool
     where
         I: Nr,
@@ -195,6 +204,7 @@ impl NVIC {
     }
 
     /// Checks if `interrupt` is pending
+    #[inline]
     pub fn is_pending<I>(interrupt: I) -> bool
     where
         I: Nr,
@@ -207,6 +217,7 @@ impl NVIC {
     }
 
     /// Forces `interrupt` into pending state
+    #[inline]
     pub fn pend<I>(interrupt: I)
     where
         I: Nr,
@@ -219,6 +230,7 @@ impl NVIC {
 
     /// Forces `interrupt` into pending state
     #[deprecated(since = "0.5.8", note = "Use `NVIC::pend`")]
+    #[inline]
     pub fn set_pending<I>(&mut self, interrupt: I)
     where
         I: Nr,
@@ -238,6 +250,7 @@ impl NVIC {
     ///
     /// Changing priority levels can break priority-based critical sections (see
     /// [`register::basepri`](../register/basepri/index.html)) and compromise memory safety.
+    #[inline]
     pub unsafe fn set_priority<I>(&mut self, interrupt: I, prio: u8)
     where
         I: Nr,
@@ -260,6 +273,7 @@ impl NVIC {
     }
 
     /// Clears `interrupt`'s pending state
+    #[inline]
     pub fn unpend<I>(interrupt: I)
     where
         I: Nr,
@@ -271,6 +285,7 @@ impl NVIC {
     }
 
     #[cfg(armv6m)]
+    #[inline]
     fn ipr_index<I>(interrupt: &I) -> usize
     where
         I: Nr,
@@ -279,6 +294,7 @@ impl NVIC {
     }
 
     #[cfg(armv6m)]
+    #[inline]
     fn ipr_shift<I>(interrupt: &I) -> usize
     where
         I: Nr,

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -120,16 +120,19 @@ use self::fpu_consts::*;
 #[cfg(has_fpu)]
 impl SCB {
     /// Shorthand for `set_fpu_access_mode(FpuAccessMode::Disabled)`
+    #[inline]
     pub fn disable_fpu(&mut self) {
         self.set_fpu_access_mode(FpuAccessMode::Disabled)
     }
 
     /// Shorthand for `set_fpu_access_mode(FpuAccessMode::Enabled)`
+    #[inline]
     pub fn enable_fpu(&mut self) {
         self.set_fpu_access_mode(FpuAccessMode::Enabled)
     }
 
     /// Gets FPU access mode
+    #[inline]
     pub fn fpu_access_mode() -> FpuAccessMode {
         // NOTE(unsafe) atomic read operation with no side effects
         let cpacr = unsafe { (*Self::ptr()).cpacr.read() };
@@ -149,6 +152,7 @@ impl SCB {
     /// floating-point arguments or have any floating-point local variables. Because the compiler
     /// might inline such a function into a caller that does have floating-point arguments or
     /// variables, any such function must be also marked #[inline(never)].
+    #[inline]
     pub fn set_fpu_access_mode(&mut self, mode: FpuAccessMode) {
         let mut cpacr = self.cpacr.read() & !SCB_CPACR_FPU_MASK;
         match mode {
@@ -162,6 +166,7 @@ impl SCB {
 
 impl SCB {
     /// Returns the active exception number
+    #[inline]
     pub fn vect_active() -> VectActive {
         let icsr = unsafe { ptr::read(&(*SCB::ptr()).icsr as *const _ as *const u32) };
 
@@ -230,6 +235,7 @@ impl Exception {
     /// Returns the IRQ number of this `Exception`
     ///
     /// The return value is always within the closed range `[-1, -14]`
+    #[inline]
     pub fn irqn(self) -> i8 {
         match self {
             Exception::NonMaskableInt => -14,
@@ -269,6 +275,7 @@ pub enum VectActive {
 
 impl VectActive {
     /// Converts a `byte` into `VectActive`
+    #[inline]
     pub fn from(vect_active: u8) -> Option<Self> {
         Some(match vect_active {
             0 => VectActive::ThreadMode,
@@ -582,6 +589,7 @@ const SCB_SCR_SLEEPDEEP: u32 = 0x1 << 2;
 
 impl SCB {
     /// Set the SLEEPDEEP bit in the SCR register
+    #[inline]
     pub fn set_sleepdeep(&mut self) {
         unsafe {
             self.scr.modify(|scr| scr | SCB_SCR_SLEEPDEEP);
@@ -589,6 +597,7 @@ impl SCB {
     }
 
     /// Clear the SLEEPDEEP bit in the SCR register
+    #[inline]
     pub fn clear_sleepdeep(&mut self) {
         unsafe {
             self.scr.modify(|scr| scr & !SCB_SCR_SLEEPDEEP);
@@ -600,6 +609,7 @@ const SCB_SCR_SLEEPONEXIT: u32 = 0x1 << 1;
 
 impl SCB {
     /// Set the SLEEPONEXIT bit in the SCR register
+    #[inline]
     pub fn set_sleeponexit(&mut self) {
         unsafe {
             self.scr.modify(|scr| scr | SCB_SCR_SLEEPONEXIT);
@@ -607,6 +617,7 @@ impl SCB {
     }
 
     /// Clear the SLEEPONEXIT bit in the SCR register
+    #[inline]
     pub fn clear_sleeponexit(&mut self) {
         unsafe {
             self.scr.modify(|scr| scr & !SCB_SCR_SLEEPONEXIT);
@@ -621,6 +632,7 @@ const SCB_AIRCR_SYSRESETREQ: u32 = 1 << 2;
 impl SCB {
     /// Initiate a system reset request to reset the MCU
     #[deprecated(since = "0.6.1", note = "Use `SCB::sys_reset`")]
+    #[inline]
     pub fn system_reset(&mut self) -> ! {
         crate::asm::dsb();
         unsafe {
@@ -640,6 +652,7 @@ impl SCB {
     }
 
     /// Initiate a system reset request to reset the MCU
+    #[inline]
     pub fn sys_reset() -> ! {
         crate::asm::dsb();
         unsafe {
@@ -667,6 +680,7 @@ const SCB_ICSR_PENDSTCLR: u32 = 1 << 25;
 
 impl SCB {
     /// Set the PENDSVSET bit in the ICSR register which will pend the PendSV interrupt
+    #[inline]
     pub fn set_pendsv() {
         unsafe {
             (*Self::ptr()).icsr.write(SCB_ICSR_PENDSVSET);
@@ -674,11 +688,13 @@ impl SCB {
     }
 
     /// Check if PENDSVSET bit in the ICSR register is set meaning PendSV interrupt is pending
+    #[inline]
     pub fn is_pendsv_pending() -> bool {
         unsafe { (*Self::ptr()).icsr.read() & SCB_ICSR_PENDSVSET == SCB_ICSR_PENDSVSET }
     }
 
     /// Set the PENDSVCLR bit in the ICSR register which will clear a pending PendSV interrupt
+    #[inline]
     pub fn clear_pendsv() {
         unsafe {
             (*Self::ptr()).icsr.write(SCB_ICSR_PENDSVCLR);
@@ -768,6 +784,7 @@ impl SCB {
     ///
     /// *NOTE*: Hardware priority does not exactly match logical priority levels. See
     /// [`NVIC.get_priority`](struct.NVIC.html#method.get_priority) for more details.
+    #[inline]
     pub fn get_priority(system_handler: SystemHandler) -> u8 {
         let index = system_handler.index();
 
@@ -798,6 +815,7 @@ impl SCB {
     ///
     /// Changing priority levels can break priority-based critical sections (see
     /// [`register::basepri`](../register/basepri/index.html)) and compromise memory safety.
+    #[inline]
     pub unsafe fn set_priority(&mut self, system_handler: SystemHandler, prio: u8) {
         let index = system_handler.index();
 

--- a/src/peripheral/syst.rs
+++ b/src/peripheral/syst.rs
@@ -40,16 +40,19 @@ impl SYST {
     /// Clears current value to 0
     ///
     /// After calling `clear_current()`, the next call to `has_wrapped()` will return `false`.
+    #[inline]
     pub fn clear_current(&mut self) {
         unsafe { self.cvr.write(0) }
     }
 
     /// Disables counter
+    #[inline]
     pub fn disable_counter(&mut self) {
         unsafe { self.csr.modify(|v| v & !SYST_CSR_ENABLE) }
     }
 
     /// Disables SysTick interrupt
+    #[inline]
     pub fn disable_interrupt(&mut self) {
         unsafe { self.csr.modify(|v| v & !SYST_CSR_TICKINT) }
     }
@@ -66,11 +69,13 @@ impl SYST {
     /// - Program Control and Status register"
     ///
     /// The sequence translates to `self.set_reload(x); self.clear_current(); self.enable_counter()`
+    #[inline]
     pub fn enable_counter(&mut self) {
         unsafe { self.csr.modify(|v| v | SYST_CSR_ENABLE) }
     }
 
     /// Enables SysTick interrupt
+    #[inline]
     pub fn enable_interrupt(&mut self) {
         unsafe { self.csr.modify(|v| v | SYST_CSR_TICKINT) }
     }
@@ -79,6 +84,7 @@ impl SYST {
     ///
     /// *NOTE* This takes `&mut self` because the read operation is side effectful and can clear the
     /// bit that indicates that the timer has wrapped (cf. `SYST.has_wrapped`)
+    #[inline]
     pub fn get_clock_source(&mut self) -> SystClkSource {
         // NOTE(unsafe) atomic read with no side effects
         if self.csr.read() & SYST_CSR_CLKSOURCE != 0 {
@@ -89,12 +95,14 @@ impl SYST {
     }
 
     /// Gets current value
+    #[inline]
     pub fn get_current() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
         unsafe { (*Self::ptr()).cvr.read() }
     }
 
     /// Gets reload value
+    #[inline]
     pub fn get_reload() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
         unsafe { (*Self::ptr()).rvr.read() }
@@ -105,12 +113,14 @@ impl SYST {
     ///
     /// Returns `0` if the value is not known (e.g. because the clock can
     /// change dynamically).
+    #[inline]
     pub fn get_ticks_per_10ms() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
         unsafe { (*Self::ptr()).calib.read() & SYST_COUNTER_MASK }
     }
 
     /// Checks if an external reference clock is available
+    #[inline]
     pub fn has_reference_clock() -> bool {
         // NOTE(unsafe) atomic read with no side effects
         unsafe { (*Self::ptr()).calib.read() & SYST_CALIB_NOREF == 0 }
@@ -120,6 +130,7 @@ impl SYST {
     ///
     /// *NOTE* This takes `&mut self` because the read operation is side effectful and will clear
     /// the bit of the read register.
+    #[inline]
     pub fn has_wrapped(&mut self) -> bool {
         self.csr.read() & SYST_CSR_COUNTFLAG != 0
     }
@@ -128,6 +139,7 @@ impl SYST {
     ///
     /// *NOTE* This takes `&mut self` because the read operation is side effectful and can clear the
     /// bit that indicates that the timer has wrapped (cf. `SYST.has_wrapped`)
+    #[inline]
     pub fn is_counter_enabled(&mut self) -> bool {
         self.csr.read() & SYST_CSR_ENABLE != 0
     }
@@ -136,6 +148,7 @@ impl SYST {
     ///
     /// *NOTE* This takes `&mut self` because the read operation is side effectful and can clear the
     /// bit that indicates that the timer has wrapped (cf. `SYST.has_wrapped`)
+    #[inline]
     pub fn is_interrupt_enabled(&mut self) -> bool {
         self.csr.read() & SYST_CSR_TICKINT != 0
     }
@@ -145,12 +158,14 @@ impl SYST {
     /// Returns `false` if using the reload value returned by
     /// `get_ticks_per_10ms()` may result in a period significantly deviating
     /// from 10 ms.
+    #[inline]
     pub fn is_precise() -> bool {
         // NOTE(unsafe) atomic read with no side effects
         unsafe { (*Self::ptr()).calib.read() & SYST_CALIB_SKEW == 0 }
     }
 
     /// Sets clock source
+    #[inline]
     pub fn set_clock_source(&mut self, clk_source: SystClkSource) {
         match clk_source {
             SystClkSource::External => unsafe { self.csr.modify(|v| v & !SYST_CSR_CLKSOURCE) },
@@ -163,6 +178,7 @@ impl SYST {
     /// Valid values are between `1` and `0x00ffffff`.
     ///
     /// *NOTE* To make the timer wrap every `N` ticks set the reload value to `N - 1`
+    #[inline]
     pub fn set_reload(&mut self, value: u32) {
         unsafe { self.rvr.write(value) }
     }

--- a/src/register/apsr.rs
+++ b/src/register/apsr.rs
@@ -8,31 +8,37 @@ pub struct Apsr {
 
 impl Apsr {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(self) -> u32 {
         self.bits
     }
 
     /// DSP overflow and saturation flag
+    #[inline]
     pub fn q(self) -> bool {
         self.bits & (1 << 27) == (1 << 27)
     }
 
     /// Overflow flag
+    #[inline]
     pub fn v(self) -> bool {
         self.bits & (1 << 28) == (1 << 28)
     }
 
     /// Carry or borrow flag
+    #[inline]
     pub fn c(self) -> bool {
         self.bits & (1 << 29) == (1 << 29)
     }
 
     /// Zero flag
+    #[inline]
     pub fn z(self) -> bool {
         self.bits & (1 << 30) == (1 << 30)
     }
 
     /// Negative flag
+    #[inline]
     pub fn n(self) -> bool {
         self.bits & (1 << 31) == (1 << 31)
     }

--- a/src/register/faultmask.rs
+++ b/src/register/faultmask.rs
@@ -11,11 +11,13 @@ pub enum Faultmask {
 
 impl Faultmask {
     /// All exceptions are active
+    #[inline]
     pub fn is_active(self) -> bool {
         self == Faultmask::Active
     }
 
     /// All exceptions, except for NMI, are inactive
+    #[inline]
     pub fn is_inactive(self) -> bool {
         self == Faultmask::Inactive
     }

--- a/src/register/primask.rs
+++ b/src/register/primask.rs
@@ -11,11 +11,13 @@ pub enum Primask {
 
 impl Primask {
     /// All exceptions with configurable priority are active
+    #[inline]
     pub fn is_active(self) -> bool {
         self == Primask::Active
     }
 
     /// All exceptions with configurable priority are inactive
+    #[inline]
     pub fn is_inactive(self) -> bool {
         self == Primask::Inactive
     }


### PR DESCRIPTION
Now the only public non-inline functions left are:

 - `write_all`
 - `write_aligned`
 - All (derived) `Debug` implementations

(Checked using Clippy's [`missing_inline_in_public_items`][1] lint.)

[1]: https://rust-lang.github.io/rust-clippy/master/#missing_inline_in_public_items