### PR TITLE
Enable the missing_inline_in_public_items clippy lint.

### DIFF
--- a/src/itm.rs
+++ b/src/itm.rs
@@ -9,6 +9,7 @@ use aligned::{Aligned, A4};
 use crate::peripheral::itm::Stim;
 
 // NOTE assumes that `bytes` is 32-bit aligned
+#[allow(clippy::missing_inline_in_public_items)]
 unsafe fn write_words(stim: &mut Stim, bytes: &[u32]) {
     let mut p = bytes.as_ptr();
     for _ in 0..bytes.len() {
@@ -30,6 +31,7 @@ impl<'p> fmt::Write for Port<'p> {
 
 /// Writes a `buffer` to the ITM `port`
 #[allow(clippy::cast_ptr_alignment)]
+#[allow(clippy::missing_inline_in_public_items)]
 #[allow(clippy::transmute_ptr_to_ptr)]
 pub fn write_all(port: &mut Stim, buffer: &[u8]) {
     unsafe {
@@ -90,6 +92,7 @@ pub fn write_all(port: &mut Stim, buffer: &[u8]) {
 /// itm::write_aligned(&itm.stim[0], &Aligned(*b"Hello, world!\n"));
 /// ```
 #[allow(clippy::cast_ptr_alignment)]
+#[allow(clippy::missing_inline_in_public_items)]
 #[allow(clippy::transmute_ptr_to_ptr)]
 pub fn write_aligned(port: &mut Stim, buffer: &Aligned<A4, [u8]>) {
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,20 @@
 #![no_std]
 #![allow(clippy::identity_op)]
 #![allow(clippy::missing_safety_doc)]
+
+// This makes clippy warn about public functions which are not #[inline].
+//
+// Almost all functions in this crate result in trivial or even no assembly.
+// These functions should be #[inline].
+//
+// If you do add a function that's not supposed to be #[inline], you can add
+// #[allow(clippy::missing_inline_in_public_items)] in front of it to add an
+// exception to clippy's rules.
+//
+// This should be done in case of:
+//  - A function containing non-trivial logic (such as itm::write_all); or
+//  - A generated #[derive(Debug)] function (in which case the attribute needs
+//    to be applied to the struct).
 #![deny(clippy::missing_inline_in_public_items)]
 
 extern crate aligned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 #![no_std]
 #![allow(clippy::identity_op)]
 #![allow(clippy::missing_safety_doc)]
+#![deny(clippy::missing_inline_in_public_items)]
 
 extern crate aligned;
 extern crate bare_metal;

--- a/src/peripheral/cpuid.rs
+++ b/src/peripheral/cpuid.rs
@@ -66,6 +66,7 @@ pub struct RegisterBlock {
 
 /// Type of cache to select on CSSELR writes.
 #[cfg(not(armv6m))]
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CsselrCacheType {
     /// Select DCache or unified cache

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -97,6 +97,7 @@ pub struct RegisterBlock {
 
 /// FPU access mode
 #[cfg(has_fpu)]
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FpuAccessMode {
     /// FPU is not accessible
@@ -193,6 +194,7 @@ impl SCB {
 }
 
 /// Processor core exceptions (internal interrupts)
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Exception {
     /// Non maskable interrupt
@@ -258,6 +260,7 @@ impl Exception {
 }
 
 /// Active exception number
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum VectActive {
     /// Thread mode
@@ -725,6 +728,7 @@ impl SCB {
 }
 
 /// System handlers, exceptions with configurable priority
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SystemHandler {
     // NonMaskableInt, // priority is fixed

--- a/src/peripheral/syst.rs
+++ b/src/peripheral/syst.rs
@@ -18,6 +18,7 @@ pub struct RegisterBlock {
 }
 
 /// SysTick clock source
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SystClkSource {
     /// Core-provided clock

--- a/src/register/apsr.rs
+++ b/src/register/apsr.rs
@@ -1,6 +1,7 @@
 //! Application Program Status Register
 
 /// Application Program Status Register
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug)]
 pub struct Apsr {
     bits: u32,

--- a/src/register/control.rs
+++ b/src/register/control.rs
@@ -1,6 +1,7 @@
 //! Control register
 
 /// Control register
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug)]
 pub struct Control {
     bits: u32,
@@ -81,6 +82,7 @@ impl Control {
 }
 
 /// Thread mode privilege level
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Npriv {
     /// Privileged
@@ -104,6 +106,7 @@ impl Npriv {
 }
 
 /// Currently active stack pointer
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Spsel {
     /// MSP is the current stack pointer
@@ -127,6 +130,7 @@ impl Spsel {
 }
 
 /// Whether context floating-point is currently active
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Fpca {
     /// Floating-point context active.

--- a/src/register/faultmask.rs
+++ b/src/register/faultmask.rs
@@ -1,6 +1,7 @@
 //! Fault Mask Register
 
 /// All exceptions are ...
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Faultmask {
     /// Active

--- a/src/register/primask.rs
+++ b/src/register/primask.rs
@@ -1,6 +1,7 @@
 //! Priority mask register
 
 /// All exceptions with configurable priority are ...
+#[allow(clippy::missing_inline_in_public_items)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Primask {
     /// Active


### PR DESCRIPTION
This adds `#![deny(clippy::missing_inline_in_public_items)]` to make sure all functions in this crate are marked `#[inline]`, unless they are explicitly marked with `#[allow(clippy::missing_inline_in_public_items)]`.

Only three functions in this crate are not `#[inline]`:

 - `write_words`
 - `write_all`
 - `write_aligned`

Additionally, the derived `Debug` impl's also have a non-inline implementations.
This unfortunately means that the allow attribute also needs to added to any types deriving `Debug`.

See also #171 and https://github.com/rust-embedded/cortex-m/pull/174#issuecomment-547304467.