### PR TITLE
Update and improve cache operations.

### DIFF
--- a/src/peripheral/cbp.rs
+++ b/src/peripheral/cbp.rs
@@ -39,34 +39,28 @@ const CBP_SW_SET_MASK: u32 = 0x1FF << CBP_SW_SET_POS;
 
 impl CBP {
     /// I-cache invalidate all to PoU
-    #[inline]
+    #[inline(always)]
     pub fn iciallu(&mut self) {
-        unsafe {
-            self.iciallu.write(0);
-        }
+        unsafe { self.iciallu.write(0) };
     }
 
     /// I-cache invalidate by MVA to PoU
-    #[inline]
+    #[inline(always)]
     pub fn icimvau(&mut self, mva: u32) {
-        unsafe {
-            self.icimvau.write(mva);
-        }
+        unsafe { self.icimvau.write(mva) };
     }
 
     /// D-cache invalidate by MVA to PoC
-    #[inline]
-    pub fn dcimvac(&mut self, mva: u32) {
-        unsafe {
-            self.dcimvac.write(mva);
-        }
+    #[inline(always)]
+    pub unsafe fn dcimvac(&mut self, mva: u32) {
+        self.dcimvac.write(mva);
     }
 
     /// D-cache invalidate by set-way
     ///
     /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
-    #[inline]
-    pub fn dcisw(&mut self, set: u16, way: u16) {
+    #[inline(always)]
+    pub unsafe fn dcisw(&mut self, set: u16, way: u16) {
         // The ARMv7-M Architecture Reference Manual, as of Revision E.b, says these set/way
         // operations have a register data format which depends on the implementation's
         // associativity and number of sets. Specifically the 'way' and 'set' fields have
@@ -76,16 +70,14 @@ impl CBP {
         // Generic User Guide section 4.8.3. Since no other ARMv7-M implementations except the
         // Cortex-M7 have a DCACHE or ICACHE at all, it seems safe to do the same thing as the
         // CMSIS-Core implementation and use fixed values.
-        unsafe {
-            self.dcisw.write(
-                ((u32::from(way) & (CBP_SW_WAY_MASK >> CBP_SW_WAY_POS)) << CBP_SW_WAY_POS)
-                    | ((u32::from(set) & (CBP_SW_SET_MASK >> CBP_SW_SET_POS)) << CBP_SW_SET_POS),
-            );
-        }
+        self.dcisw.write(
+            ((u32::from(way) & (CBP_SW_WAY_MASK >> CBP_SW_WAY_POS)) << CBP_SW_WAY_POS)
+                | ((u32::from(set) & (CBP_SW_SET_MASK >> CBP_SW_SET_POS)) << CBP_SW_SET_POS),
+        );
     }
 
     /// D-cache clean by MVA to PoU
-    #[inline]
+    #[inline(always)]
     pub fn dccmvau(&mut self, mva: u32) {
         unsafe {
             self.dccmvau.write(mva);
@@ -93,7 +85,7 @@ impl CBP {
     }
 
     /// D-cache clean by MVA to PoC
-    #[inline]
+    #[inline(always)]
     pub fn dccmvac(&mut self, mva: u32) {
         unsafe {
             self.dccmvac.write(mva);
@@ -103,7 +95,7 @@ impl CBP {
     /// D-cache clean by set-way
     ///
     /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
-    #[inline]
+    #[inline(always)]
     pub fn dccsw(&mut self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
         unsafe {
@@ -115,7 +107,7 @@ impl CBP {
     }
 
     /// D-cache clean and invalidate by MVA to PoC
-    #[inline]
+    #[inline(always)]
     pub fn dccimvac(&mut self, mva: u32) {
         unsafe {
             self.dccimvac.write(mva);
@@ -125,7 +117,7 @@ impl CBP {
     /// D-cache clean and invalidate by set-way
     ///
     /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
-    #[inline]
+    #[inline(always)]
     pub fn dccisw(&mut self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
         unsafe {
@@ -137,7 +129,7 @@ impl CBP {
     }
 
     /// Branch predictor invalidate all
-    #[inline]
+    #[inline(always)]
     pub fn bpiall(&mut self) {
         unsafe {
             self.bpiall.write(0);

--- a/src/peripheral/cpuid.rs
+++ b/src/peripheral/cpuid.rs
@@ -114,4 +114,27 @@ impl CPUID {
             (1 + ((ccsidr & CCSIDR_ASSOCIATIVITY_MASK) >> CCSIDR_ASSOCIATIVITY_POS)) as u16,
         )
     }
+
+    /// Returns log2 of the number of words in the smallest cache line of all the data cache and
+    /// unified caches that are controlled by the processor.
+    ///
+    /// This is the `DminLine` field of the CTR register.
+    #[inline(always)]
+    pub fn cache_dminline() -> u32 {
+        const CTR_DMINLINE_POS: u32 = 16;
+        const CTR_DMINLINE_MASK: u32 = 0xF << CTR_DMINLINE_POS;
+        let ctr = unsafe { (*Self::ptr()).ctr.read() };
+        (ctr & CTR_DMINLINE_MASK) >> CTR_DMINLINE_POS
+    }
+
+    /// Returns log2 of the number of words in the smallest cache line of all the instruction
+    /// caches that are controlled by the processor.
+    ///
+    /// This is the `IminLine` field of the CTR register.
+    pub fn cache_iminline() -> u32 {
+        const CTR_IMINLINE_POS: u32 = 0;
+        const CTR_IMINLINE_MASK: u32 = 0xF << CTR_IMINLINE_POS;
+        let ctr = unsafe { (*Self::ptr()).ctr.read() };
+        (ctr & CTR_IMINLINE_MASK) >> CTR_IMINLINE_POS
+    }
 }

--- a/src/peripheral/cpuid.rs
+++ b/src/peripheral/cpuid.rs
@@ -131,6 +131,7 @@ impl CPUID {
     /// caches that are controlled by the processor.
     ///
     /// This is the `IminLine` field of the CTR register.
+    #[inline(always)]
     pub fn cache_iminline() -> u32 {
         const CTR_IMINLINE_POS: u32 = 0;
         const CTR_IMINLINE_MASK: u32 = 0xF << CTR_IMINLINE_POS;

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -314,7 +314,7 @@ use self::scb_consts::*;
 
 #[cfg(not(armv6m))]
 impl SCB {
-    /// Enables I-cache if currently disabled
+    /// Enables I-cache if currently disabled.
     ///
     /// This operation first invalidates the entire I-cache.
     #[inline]
@@ -338,7 +338,7 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Disables I-cache if currently enabled
+    /// Disables I-cache if currently enabled.
     ///
     /// This operation invalidates the entire I-cache after disabling.
     #[inline]
@@ -362,7 +362,7 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Returns whether the I-cache is currently enabled
+    /// Returns whether the I-cache is currently enabled.
     #[inline(always)]
     pub fn icache_enabled() -> bool {
         crate::asm::dsb();
@@ -372,7 +372,7 @@ impl SCB {
         unsafe { (*Self::ptr()).ccr.read() & SCB_CCR_IC_MASK == SCB_CCR_IC_MASK }
     }
 
-    /// Invalidates entire I-cache
+    /// Invalidates the entire I-cache.
     #[inline]
     pub fn invalidate_icache(&mut self) {
         // NOTE(unsafe): No races as all CBP registers are write-only and stateless
@@ -385,7 +385,7 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Enables D-cache if currently disabled
+    /// Enables D-cache if currently disabled.
     ///
     /// This operation first invalidates the entire D-cache, ensuring it does
     /// not contain stale values before being enabled.
@@ -407,7 +407,7 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Disables D-cache if currently enabled
+    /// Disables D-cache if currently enabled.
     ///
     /// This operation subsequently cleans and invalidates the entire D-cache,
     /// ensuring all contents are safely written back to main memory after disabling.
@@ -426,7 +426,7 @@ impl SCB {
         self.clean_invalidate_dcache(cpuid);
     }
 
-    /// Returns whether the D-cache is currently enabled
+    /// Returns whether the D-cache is currently enabled.
     #[inline]
     pub fn dcache_enabled() -> bool {
         crate::asm::dsb();
@@ -436,7 +436,7 @@ impl SCB {
         unsafe { (*Self::ptr()).ccr.read() & SCB_CCR_DC_MASK == SCB_CCR_DC_MASK }
     }
 
-    /// Invalidates entire D-cache
+    /// Invalidates the entire D-cache.
     ///
     /// Note that calling this while the dcache is enabled will probably wipe out the
     /// stack, depending on optimisations, therefore breaking returning to the call point.
@@ -461,7 +461,7 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Cleans entire D-cache
+    /// Cleans the entire D-cache.
     ///
     /// This function causes everything in the D-cache to be written back to main memory,
     /// overwriting whatever is already there.
@@ -483,7 +483,7 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Cleans and invalidates entire D-cache
+    /// Cleans and invalidates the entire D-cache.
     ///
     /// This function causes everything in the D-cache to be written back to main memory,
     /// and then marks the entire D-cache as invalid, causing future reads to first fetch
@@ -506,10 +506,10 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Invalidates D-cache by address
+    /// Invalidates D-cache by address.
     ///
-    /// * `addr`: the address to invalidate, which must be cache-line aligned
-    /// * `size`: number of bytes to invalidate, which must be a multiple of the cache line size
+    /// * `addr`: The address to invalidate, which must be cache-line aligned.
+    /// * `size`: Number of bytes to invalidate, which must be a multiple of the cache line size.
     ///
     /// Invalidates D-cache cache lines, starting from the first line containing `addr`,
     /// finishing once at least `size` bytes have been invalidated.
@@ -530,7 +530,7 @@ impl SCB {
     /// # Safety
     ///
     /// After invalidating, the next read of invalidated data will be from main memory. This may
-    /// cause recent writes to be lost, potentially including writes that initialised objects.
+    /// cause recent writes to be lost, potentially including writes that initialized objects.
     /// Therefore, this method may cause uninitialised memory or invalid values to be read,
     /// resulting in undefined behaviour. You must ensure that main memory contains valid and
     /// initialised values before invalidating.
@@ -575,9 +575,9 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Invalidates an object from the D-cache
+    /// Invalidates an object from the D-cache.
     ///
-    /// * `obj`: Object to invalidate
+    /// * `obj`: The object to invalidate.
     ///
     /// Invalidates D-cache starting from the first cache line containing `obj`,
     /// continuing to invalidate cache lines until all of `obj` has been invalidated.
@@ -613,9 +613,9 @@ impl SCB {
         self.invalidate_dcache_by_address(obj as *const T as usize, core::mem::size_of::<T>());
     }
 
-    /// Invalidates a slice from the D-cache
+    /// Invalidates a slice from the D-cache.
     ///
-    /// * `slice`: Slice to invalidate
+    /// * `slice`: The slice to invalidate.
     ///
     /// Invalidates D-cache starting from the first cache line containing members of `slice`,
     /// continuing to invalidate cache lines until all of `slice` has been invalidated.
@@ -652,10 +652,10 @@ impl SCB {
                                           slice.len() * core::mem::size_of::<T>());
     }
 
-    /// Cleans D-cache by address
+    /// Cleans D-cache by address.
     ///
-    /// * `addr`: the address to clean
-    /// * `size`: number of bytes to clean
+    /// * `addr`: The address to start cleaning at.
+    /// * `size`: The number of bytes to clean.
     ///
     /// Cleans D-cache cache lines, starting from the first line containing `addr`,
     /// finishing once at least `size` bytes have been invalidated.
@@ -701,9 +701,9 @@ impl SCB {
         crate::asm::isb();
     }
 
-    /// Cleans an object in D-cache
+    /// Cleans an object from the D-cache.
     ///
-    /// * `obj`: Object to clean
+    /// * `obj`: The object to clean.
     ///
     /// Cleans D-cache starting from the first cache line containing `obj`,
     /// continuing to clean cache lines until all of `obj` has been cleaned.
@@ -717,9 +717,9 @@ impl SCB {
         self.clean_dcache_by_address(obj as *const T as usize, core::mem::size_of::<T>());
     }
 
-    /// Cleans a slice in D-cache
+    /// Cleans a slice from D-cache.
     ///
-    /// * `slice`: Slice to clean
+    /// * `slice`: The slice to clean.
     ///
     /// Cleans D-cache starting from the first cache line containing members of `slice`,
     /// continuing to clean cache lines until all of `slice` has been cleaned.
@@ -734,10 +734,10 @@ impl SCB {
                                      slice.len() * core::mem::size_of::<T>());
     }
 
-    /// Cleans and invalidates D-cache by address
+    /// Cleans and invalidates D-cache by address.
     ///
-    /// * `addr`: the address to clean and invalidate
-    /// * `size`: number of bytes to clean and invalidate
+    /// * `addr`: The address to clean and invalidate.
+    /// * `size`: The number of bytes to clean and invalidate.
     ///
     /// Cleans and invalidates D-cache starting from the first cache line containing `addr`,
     /// finishing once at least `size` bytes have been cleaned and invalidated.

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -531,9 +531,9 @@ impl SCB {
     ///
     /// After invalidating, the next read of invalidated data will be from main memory. This may
     /// cause recent writes to be lost, potentially including writes that initialized objects.
-    /// Therefore, this method may cause uninitialised memory or invalid values to be read,
+    /// Therefore, this method may cause uninitialized memory or invalid values to be read,
     /// resulting in undefined behaviour. You must ensure that main memory contains valid and
-    /// initialised values before invalidating.
+    /// initialized values before invalidating.
     ///
     /// `addr` **must** be aligned to the size of the cache lines, and `size` **must** be a
     /// multiple of the cache line size, otherwise this function will invalidate other memory,
@@ -598,10 +598,10 @@ impl SCB {
     /// # Safety
     ///
     /// After invalidating, `obj` will be read from main memory on next access. This may cause
-    /// recent writes to `obj` to be lost, potentially including the write that initialised it.
-    /// Therefore, this method may cause uninitialised memory or invalid values to be read,
+    /// recent writes to `obj` to be lost, potentially including the write that initialized it.
+    /// Therefore, this method may cause uninitialized memory or invalid values to be read,
     /// resulting in undefined behaviour. You must ensure that main memory contains a valid and
-    /// initialised value for T before invalidating `obj`.
+    /// initialized value for T before invalidating `obj`.
     ///
     /// `obj` **must** be aligned to the size of the cache lines, and its size **must** be a
     /// multiple of the cache line size, otherwise this function will invalidate other memory,
@@ -636,10 +636,10 @@ impl SCB {
     /// # Safety
     ///
     /// After invalidating, `slice` will be read from main memory on next access. This may cause
-    /// recent writes to `slice` to be lost, potentially including the write that initialised it.
-    /// Therefore, this method may cause uninitialised memory or invalid values to be read,
+    /// recent writes to `slice` to be lost, potentially including the write that initialized it.
+    /// Therefore, this method may cause uninitialized memory or invalid values to be read,
     /// resulting in undefined behaviour. You must ensure that main memory contains valid and
-    /// initialised values for T before invalidating `slice`.
+    /// initialized values for T before invalidating `slice`.
     ///
     /// `slice` **must** be aligned to the size of the cache lines, and its size **must** be a
     /// multiple of the cache line size, otherwise this function will invalidate other memory,


### PR DESCRIPTION
Closes #47, #188.

I've implemented the proposed methods from #47 and marked all d-cache invalidation functions as unsafe. It's not unsafe to invalidate i-cache or branch predictor as they are read-only caches. The clean and clean+invalidate operations do not alter memory from the executing core's point of view so are also safe.

It wasn't possible to remove the requirement to pass in `&mut CPUID` as you require synchronized access to `CPUID` to read the number of sets and ways in the cache, which is required to fully clean or invalidate them, which is required to enable or disable them. So it goes.

Breaking change due to changing safety of d-cache invalidation functions.