### PR TITLE
Prevent unnecessary bounds check in SCB::{get_priority, set_priority}

### DIFF
--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -951,6 +951,7 @@ impl SCB {
             // NOTE(unsafe) atomic read with no side effects
 
             // NOTE(unsafe): Index is bounded to [4,15] by SystemHandler design.
+            // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
             let priority_ref = unsafe {(*Self::ptr()).shpr.get_unchecked(usize::from(index - 4))};
 
             priority_ref.read()
@@ -961,6 +962,7 @@ impl SCB {
             // NOTE(unsafe) atomic read with no side effects
 
             // NOTE(unsafe): Index is bounded to [11,15] by SystemHandler design.
+            // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
             let priority_ref = unsafe {(*Self::ptr()).shpr.get_unchecked(usize::from((index - 8) / 4))};
 
             let shpr = priority_ref.read();
@@ -988,6 +990,7 @@ impl SCB {
         #[cfg(not(armv6m))]
         {
             // NOTE(unsafe): Index is bounded to [4,15] by SystemHandler design.
+            // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
             let priority_ref = (*Self::ptr()).shpr.get_unchecked(usize::from(index - 4));
 
             priority_ref.write(prio)
@@ -996,6 +999,7 @@ impl SCB {
         #[cfg(armv6m)]
         {
             // NOTE(unsafe): Index is bounded to [11,15] by SystemHandler design.
+            // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
             let priority_ref = (*Self::ptr()).shpr.get_unchecked(usize::from((index - 8) / 4));
 
             priority_ref.modify(|value| {

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -950,8 +950,7 @@ impl SCB {
         {
             // NOTE(unsafe) atomic read with no side effects
 
-            // NOTE(unsafe): prevent unnecessary bounds check! Index of shpr array is
-            // true by SystemHandler design.
+            // NOTE(unsafe): Index is bounded to [4,15] by SystemHandler design.
             let priority_ref = unsafe {(*Self::ptr()).shpr.get_unchecked(usize::from(index - 4))};
 
             priority_ref.read()
@@ -961,8 +960,7 @@ impl SCB {
         {
             // NOTE(unsafe) atomic read with no side effects
 
-            // NOTE(unsafe): prevent unnecessary bounds check! Index of shpr array is
-            // true by SystemHandler design.
+            // NOTE(unsafe): Index is bounded to [11,15] by SystemHandler design.
             let priority_ref = unsafe {(*Self::ptr()).shpr.get_unchecked(usize::from((index - 8) / 4))};
 
             let shpr = priority_ref.read();
@@ -989,8 +987,7 @@ impl SCB {
 
         #[cfg(not(armv6m))]
         {
-            // NOTE(unsafe): prevent unnecessary bounds check! Index of shpr array is
-            // true by SystemHandler design.
+            // NOTE(unsafe): Index is bounded to [4,15] by SystemHandler design.
             let priority_ref = (*Self::ptr()).shpr.get_unchecked(usize::from(index - 4));
 
             priority_ref.write(prio)
@@ -998,8 +995,7 @@ impl SCB {
 
         #[cfg(armv6m)]
         {
-            // NOTE(unsafe): prevent unnecessary bounds check! Index of shpr array is
-            // true by SystemHandler design.
+            // NOTE(unsafe): Index is bounded to [11,15] by SystemHandler design.
             let priority_ref = (*Self::ptr()).shpr.get_unchecked(usize::from((index - 8) / 4));
 
             priority_ref.modify(|value| {


### PR DESCRIPTION
SystemHandler.index() gives true index for SCB.shpr array.
But now it produce unnecessary bounds check. For example, SCB::set_priority:
```
48: sym.cortex_m::peripheral::scb::__impl_cortex_m::peripheral::SCB_::set_priority::h622cd21bcc3321be ();
0x08000376      push    {r7, lr}
0x08000378      mov     r7, sp
0x0800037a      bl      cortex_m::peripheral::scb::SystemHandler::index::hdaf1a31aa5a6a8c5 ; sym.cortex_m::peripheral::scb::SystemHandler::index::hdaf1a31aa5a6a8c5
0x0800037e      subs    r0, 4
0x08000380      uxtb    r0, r0
0x08000382      cmp     r0, 0xb    ; 11
0x08000384      itttt   ls
0x08000386      movw    r1, 0xed18
0x0800038a      movt    r1, 0xe000
0x0800038e      movs    r2, 0xff
0x08000390      strb    r2, [r0, r1]
0x08000392      it      ls
0x08000394      pop     {r7, pc}
0x08000396      movw    r2, 0x1dc0
0x0800039a      movs    r1, 0xc
0x0800039c      movt    r2, 0x800
0x080003a0      bl      core::panicking::panic_bounds_check::h5181f47ae17a04a5 ; sym.core::panicking::panic_bounds_check::h5181f47ae17a04a5
0x080003a4      trap
```

This PR fix it.