### PR TITLE
Use llmv_asm! macro for inline assembly

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -8,7 +8,7 @@
 pub fn bkpt() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => unsafe { asm!("bkpt" :::: "volatile") },
+        () => unsafe { llvm_asm!("bkpt" :::: "volatile") },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => unsafe {
@@ -36,7 +36,7 @@ pub fn delay(_n: u32) {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => unsafe {
-            asm!("1:
+            llvm_asm!("1:
                   nop
                   subs $0, $$1
                   bne.n 1b"
@@ -65,7 +65,7 @@ pub fn delay(_n: u32) {
 pub fn nop() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => unsafe { asm!("nop" :::: "volatile") },
+        () => unsafe { llvm_asm!("nop" :::: "volatile") },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => unsafe {
@@ -90,7 +90,7 @@ pub fn udf() -> ! {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => unsafe {
-            asm!("udf" :::: "volatile");
+            llvm_asm!("udf" :::: "volatile");
             core::hint::unreachable_unchecked();
         },
 
@@ -115,7 +115,7 @@ pub fn udf() -> ! {
 pub fn wfe() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => unsafe { asm!("wfe" :::: "volatile") },
+        () => unsafe { llvm_asm!("wfe" :::: "volatile") },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => unsafe {
@@ -136,7 +136,7 @@ pub fn wfe() {
 pub fn wfi() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => unsafe { asm!("wfi" :::: "volatile") },
+        () => unsafe { llvm_asm!("wfi" :::: "volatile") },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => unsafe {
@@ -157,7 +157,7 @@ pub fn wfi() {
 pub fn sev() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => unsafe { asm!("sev" :::: "volatile") },
+        () => unsafe { llvm_asm!("sev" :::: "volatile") },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => unsafe {
@@ -181,7 +181,7 @@ pub fn sev() {
 pub fn isb() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => unsafe { asm!("isb 0xF" ::: "memory" : "volatile") },
+        () => unsafe { llvm_asm!("isb 0xF" ::: "memory" : "volatile") },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => unsafe {
@@ -209,7 +209,7 @@ pub fn isb() {
 pub fn dsb() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => unsafe { asm!("dsb 0xF" ::: "memory" : "volatile") },
+        () => unsafe { llvm_asm!("dsb 0xF" ::: "memory" : "volatile") },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => unsafe {
@@ -235,7 +235,7 @@ pub fn dsb() {
 pub fn dmb() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => unsafe { asm!("dmb 0xF" ::: "memory" : "volatile") },
+        () => unsafe { llvm_asm!("dmb 0xF" ::: "memory" : "volatile") },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => unsafe {
@@ -267,7 +267,7 @@ pub fn tt(addr: *mut u32) -> u32 {
         () => {
             let tt_resp: u32;
             unsafe {
-                asm!("tt $0, $1" : "=r"(tt_resp) : "r"(addr) :: "volatile");
+                llvm_asm!("tt $0, $1" : "=r"(tt_resp) : "r"(addr) :: "volatile");
             }
             tt_resp
         }
@@ -302,7 +302,7 @@ pub fn ttt(addr: *mut u32) -> u32 {
         () => {
             let tt_resp: u32;
             unsafe {
-                asm!("ttt $0, $1" : "=r"(tt_resp) : "r"(addr) :: "volatile");
+                llvm_asm!("ttt $0, $1" : "=r"(tt_resp) : "r"(addr) :: "volatile");
             }
             tt_resp
         }
@@ -338,7 +338,7 @@ pub fn tta(addr: *mut u32) -> u32 {
         () => {
             let tt_resp: u32;
             unsafe {
-                asm!("tta $0, $1" : "=r"(tt_resp) : "r"(addr) :: "volatile");
+                llvm_asm!("tta $0, $1" : "=r"(tt_resp) : "r"(addr) :: "volatile");
             }
             tt_resp
         }
@@ -374,7 +374,7 @@ pub fn ttat(addr: *mut u32) -> u32 {
         () => {
             let tt_resp: u32;
             unsafe {
-                asm!("ttat $0, $1" : "=r"(tt_resp) : "r"(addr) :: "volatile");
+                llvm_asm!("ttat $0, $1" : "=r"(tt_resp) : "r"(addr) :: "volatile");
             }
             tt_resp
         }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -10,7 +10,7 @@ pub fn disable() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => unsafe {
-            asm!("cpsid i" ::: "memory" : "volatile");
+            llvm_asm!("cpsid i" ::: "memory" : "volatile");
         },
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
@@ -37,7 +37,7 @@ pub fn disable() {
 pub unsafe fn enable() {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => asm!("cpsie i" ::: "memory" : "volatile"),
+        () => llvm_asm!("cpsie i" ::: "memory" : "volatile"),
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(llvm_asm)]
 //! Low level access to Cortex-M processors
 //!
 //! This crate provides:
@@ -30,7 +29,7 @@
 //! This crate is guaranteed to compile on stable Rust 1.31 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 
-#![cfg_attr(feature = "inline-asm", feature(asm))]
+#![cfg_attr(feature = "inline-asm", feature(llvm_asm))]
 #![deny(missing_docs)]
 #![no_std]
 #![allow(clippy::identity_op)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(llvm_asm)]
 //! Low level access to Cortex-M processors
 //!
 //! This crate provides:
@@ -12,7 +13,7 @@
 //! ## `inline-asm`
 //!
 //! When this feature is enabled the implementation of all the functions inside the `asm` and
-//! `register` modules use inline assembly (`asm!`) instead of external assembly (FFI into separate
+//! `register` modules use inline assembly (`llvm_asm!`) instead of external assembly (FFI into separate
 //! assembly files pre-compiled using `arm-none-eabi-gcc`). The advantages of enabling `inline-asm`
 //! are:
 //!

--- a/src/register/apsr.rs
+++ b/src/register/apsr.rs
@@ -55,7 +55,7 @@ pub fn read() -> Apsr {
         () => {
             let r: u32;
             unsafe {
-                asm!("mrs $0, APSR" : "=r"(r) ::: "volatile");
+                llvm_asm!("mrs $0, APSR" : "=r"(r) ::: "volatile");
             }
             Apsr { bits: r }
         }

--- a/src/register/basepri.rs
+++ b/src/register/basepri.rs
@@ -8,7 +8,7 @@ pub fn read() -> u8 {
         () => {
             let r: u32;
             unsafe {
-                asm!("mrs $0, BASEPRI" : "=r"(r) ::: "volatile");
+                llvm_asm!("mrs $0, BASEPRI" : "=r"(r) ::: "volatile");
             }
             r as u8
         }
@@ -37,10 +37,10 @@ pub unsafe fn write(_basepri: u8) {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => match () {
             #[cfg(not(feature = "cm7-r0p1"))]
-            () => asm!("msr BASEPRI, $0" :: "r"(_basepri) : "memory" : "volatile"),
+            () => llvm_asm!("msr BASEPRI, $0" :: "r"(_basepri) : "memory" : "volatile"),
             #[cfg(feature = "cm7-r0p1")]
             () => crate::interrupt::free(
-                |_| asm!("msr BASEPRI, $0" :: "r"(_basepri) : "memory" : "volatile"),
+                |_| llvm_asm!("msr BASEPRI, $0" :: "r"(_basepri) : "memory" : "volatile"),
             ),
         },
 

--- a/src/register/basepri_max.rs
+++ b/src/register/basepri_max.rs
@@ -14,10 +14,10 @@ pub fn write(_basepri: u8) {
         () => unsafe {
             match () {
                 #[cfg(not(feature = "cm7-r0p1"))]
-                () => asm!("msr BASEPRI_MAX, $0" :: "r"(_basepri) : "memory" : "volatile"),
+                () => llvm_asm!("msr BASEPRI_MAX, $0" :: "r"(_basepri) : "memory" : "volatile"),
                 #[cfg(feature = "cm7-r0p1")]
                 () => crate::interrupt::free(
-                    |_| asm!("msr BASEPRI_MAX, $0" :: "r"(_basepri) : "memory" : "volatile"),
+                    |_| llvm_asm!("msr BASEPRI_MAX, $0" :: "r"(_basepri) : "memory" : "volatile"),
                 ),
             }
         },

--- a/src/register/control.rs
+++ b/src/register/control.rs
@@ -163,7 +163,7 @@ pub fn read() -> Control {
                 #[cfg(feature = "inline-asm")]
                 () => {
                     let r: u32;
-                    unsafe { asm!("mrs $0, CONTROL" : "=r"(r) ::: "volatile") }
+                    unsafe { llvm_asm!("mrs $0, CONTROL" : "=r"(r) ::: "volatile") }
                     r
                 }
 
@@ -194,7 +194,7 @@ pub unsafe fn write(_control: Control) {
             #[cfg(feature = "inline-asm")]
             () => {
                 let control = _control.bits();
-                asm!("msr CONTROL, $0" :: "r"(control) : "memory" : "volatile");
+                llvm_asm!("msr CONTROL, $0" :: "r"(control) : "memory" : "volatile");
             }
 
             #[cfg(not(feature = "inline-asm"))]

--- a/src/register/faultmask.rs
+++ b/src/register/faultmask.rs
@@ -34,7 +34,7 @@ pub fn read() -> Faultmask {
                 #[cfg(feature = "inline-asm")]
                 () => {
                     let r: u32;
-                    unsafe { asm!("mrs $0, FAULTMASK" : "=r"(r) ::: "volatile") }
+                    unsafe { llvm_asm!("mrs $0, FAULTMASK" : "=r"(r) ::: "volatile") }
                     r
                 }
 

--- a/src/register/lr.rs
+++ b/src/register/lr.rs
@@ -9,7 +9,7 @@ pub fn read() -> u32 {
         #[cfg(cortex_m)]
         () => {
             let r: u32;
-            unsafe { asm!("mov $0,R14" : "=r"(r) ::: "volatile") }
+            unsafe { llvm_asm!("mov $0,R14" : "=r"(r) ::: "volatile") }
             r
         }
 
@@ -25,7 +25,7 @@ pub fn read() -> u32 {
 pub unsafe fn write(_bits: u32) {
     match () {
         #[cfg(cortex_m)]
-        () => asm!("mov R14,$0" :: "r"(_bits) :: "volatile"),
+        () => llvm_asm!("mov R14,$0" :: "r"(_bits) :: "volatile"),
 
         #[cfg(not(cortex_m))]
         () => unimplemented!(),

--- a/src/register/msp.rs
+++ b/src/register/msp.rs
@@ -7,7 +7,7 @@ pub fn read() -> u32 {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => {
             let r;
-            unsafe { asm!("mrs $0,MSP" : "=r"(r) ::: "volatile") }
+            unsafe { llvm_asm!("mrs $0,MSP" : "=r"(r) ::: "volatile") }
             r
         }
 
@@ -30,7 +30,7 @@ pub fn read() -> u32 {
 pub unsafe fn write(_bits: u32) {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => asm!("msr MSP,$0" :: "r"(_bits) :: "volatile"),
+        () => llvm_asm!("msr MSP,$0" :: "r"(_bits) :: "volatile"),
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => {

--- a/src/register/msplim.rs
+++ b/src/register/msplim.rs
@@ -7,7 +7,7 @@ pub fn read() -> u32 {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => {
             let r;
-            unsafe { asm!("mrs $0,MSPLIM" : "=r"(r) ::: "volatile") }
+            unsafe { llvm_asm!("mrs $0,MSPLIM" : "=r"(r) ::: "volatile") }
             r
         }
 
@@ -30,7 +30,7 @@ pub fn read() -> u32 {
 pub unsafe fn write(_bits: u32) {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => asm!("msr MSPLIM,$0" :: "r"(_bits) :: "volatile"),
+        () => llvm_asm!("msr MSPLIM,$0" :: "r"(_bits) :: "volatile"),
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => {

--- a/src/register/pc.rs
+++ b/src/register/pc.rs
@@ -9,7 +9,7 @@ pub fn read() -> u32 {
         #[cfg(cortex_m)]
         () => {
             let r;
-            unsafe { asm!("mov $0,R15" : "=r"(r) ::: "volatile") }
+            unsafe { llvm_asm!("mov $0,R15" : "=r"(r) ::: "volatile") }
             r
         }
 
@@ -25,7 +25,7 @@ pub fn read() -> u32 {
 pub unsafe fn write(_bits: u32) {
     match () {
         #[cfg(cortex_m)]
-        () => asm!("mov R15,$0" :: "r"(_bits) :: "volatile"),
+        () => llvm_asm!("mov R15,$0" :: "r"(_bits) :: "volatile"),
 
         #[cfg(not(cortex_m))]
         () => unimplemented!(),

--- a/src/register/primask.rs
+++ b/src/register/primask.rs
@@ -34,7 +34,7 @@ pub fn read() -> Primask {
                 #[cfg(feature = "inline-asm")]
                 () => {
                     let r: u32;
-                    unsafe { asm!("mrs $0, PRIMASK" : "=r"(r) ::: "volatile") }
+                    unsafe { llvm_asm!("mrs $0, PRIMASK" : "=r"(r) ::: "volatile") }
                     r
                 }
 

--- a/src/register/psp.rs
+++ b/src/register/psp.rs
@@ -7,7 +7,7 @@ pub fn read() -> u32 {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => {
             let r;
-            unsafe { asm!("mrs $0,PSP" : "=r"(r) ::: "volatile") }
+            unsafe { llvm_asm!("mrs $0,PSP" : "=r"(r) ::: "volatile") }
             r
         }
 
@@ -30,7 +30,7 @@ pub fn read() -> u32 {
 pub unsafe fn write(_bits: u32) {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => asm!("msr PSP,$0" :: "r"(_bits) :: "volatile"),
+        () => llvm_asm!("msr PSP,$0" :: "r"(_bits) :: "volatile"),
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => {

--- a/src/register/psplim.rs
+++ b/src/register/psplim.rs
@@ -7,7 +7,7 @@ pub fn read() -> u32 {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => {
             let r;
-            unsafe { asm!("mrs $0,PSPLIM" : "=r"(r) ::: "volatile") }
+            unsafe { llvm_asm!("mrs $0,PSPLIM" : "=r"(r) ::: "volatile") }
             r
         }
 
@@ -30,7 +30,7 @@ pub fn read() -> u32 {
 pub unsafe fn write(_bits: u32) {
     match () {
         #[cfg(all(cortex_m, feature = "inline-asm"))]
-        () => asm!("msr PSPLIM,$0" :: "r"(_bits) :: "volatile"),
+        () => llvm_asm!("msr PSPLIM,$0" :: "r"(_bits) :: "volatile"),
 
         #[cfg(all(cortex_m, not(feature = "inline-asm")))]
         () => {


### PR DESCRIPTION
Fixes #204

the `asm!` macro will soon be deprecated.
This changes all of the `asm!` calls to `llvm_asm!`

To my knowledge doing a direct replacement should be fine.
