### PR TITLE
ITM: don't test reserved bits in is_fifo_ready

### DIFF
--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -55,6 +55,6 @@ impl Stim {
     /// Returns `true` if the stimulus port is ready to accept more data
     #[inline]
     pub fn is_fifo_ready(&self) -> bool {
-        unsafe { ptr::read_volatile(self.register.get()) == 1 }
+        unsafe { ptr::read_volatile(self.register.get()) & 1 == 1 }
     }
 }


### PR DESCRIPTION
On ARMv7-M, bits 31:1 of the value read from STIMx are reserved, so
comparing them against zero is a bad idea.

On ARMv8-M, bit 1 has been repurposed to indicate DISABLED. This means
that the is_fifo_ready impl hangs forever when ITM is disabled on a
Cortex-M33 (for example).

Changed to test only the FIFOREADY bit.

@bcantrill