### PR TITLE
Initial ARMv8-M MPU support.

### DIFF
--- a/src/peripheral/mpu.rs
+++ b/src/peripheral/mpu.rs
@@ -2,7 +2,8 @@
 
 use volatile_register::{RO, RW};
 
-/// Register block
+/// Register block for ARMv7-M
+#[cfg(any(armv6m, armv7m, target_arch = "x86_64"))] // x86-64 is for rustdoc
 #[repr(C)]
 pub struct RegisterBlock {
     /// Type
@@ -27,4 +28,38 @@ pub struct RegisterBlock {
     pub rbar_a3: RW<u32>,
     /// Alias 3 of RSAR
     pub rsar_a3: RW<u32>,
+}
+
+/// Register block for ARMv8-M
+#[cfg(armv8m)]
+#[repr(C)]
+pub struct RegisterBlock {
+    /// Type
+    pub _type: RO<u32>,
+    /// Control
+    pub ctrl: RW<u32>,
+    /// Region Number
+    pub rnr: RW<u32>,
+    /// Region Base Address
+    pub rbar: RW<u32>,
+    /// Region Limit Address
+    pub rlar: RW<u32>,
+    /// Alias 1 of RBAR
+    pub rbar_a1: RW<u32>,
+    /// Alias 1 of RLAR
+    pub rlar_a1: RW<u32>,
+    /// Alias 2 of RBAR
+    pub rbar_a2: RW<u32>,
+    /// Alias 2 of RLAR
+    pub rlar_a2: RW<u32>,
+    /// Alias 3 of RBAR
+    pub rbar_a3: RW<u32>,
+    /// Alias 3 of RLAR
+    pub rlar_a3: RW<u32>,
+
+    // Reserved word at offset 0xBC
+    _reserved: u32,
+
+    /// Memory Attribute Indirection register 0 and 1
+    pub mair: [RW<u32>; 2],
 }


### PR DESCRIPTION
The v8-M MPU is entirely different from, and incompatible with, the
earlier PMSA MPU. And so this commit does two things:

1. Makes the old RegisterBlock depend on armv6m (for M0+) and armv7m.

2. Defines a new RegisterBlock containing the right layout for v8m.

The hack for documenting fields by opting in x86-64 means the v8m
version won't appear in the docs.