### PR TITLE
ITM: don't test reserved bits in is_fifo_ready

### DIFF
--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -53,8 +53,19 @@ impl Stim {
     }
 
     /// Returns `true` if the stimulus port is ready to accept more data
+    #[cfg(not(armv8m))]
     #[inline]
     pub fn is_fifo_ready(&self) -> bool {
-        unsafe { ptr::read_volatile(self.register.get()) & 1 == 1 }
+        unsafe { ptr::read_volatile(self.register.get()) & 0b1 == 1 }
+    }
+
+    /// Returns `true` if the stimulus port is ready to accept more data
+    #[cfg(armv8m)]
+    #[inline]
+    pub fn is_fifo_ready(&self) -> bool {
+        // ARMv8-M adds a disabled bit; we indicate that we are ready to
+        // proceed with a stimulus write if the port is either ready (bit 0) or
+        // disabled (bit 1).
+        unsafe { ptr::read_volatile(self.register.get()) & 0b11 != 0 }
     }
 }


### PR DESCRIPTION
This is a follow up to the discussion in #219, capturing the conclusion by @cbiffle  and @adamgreig there: to indicate that the ITM FIFO is ready on FIFOREADY (only) on ARMv7-M (only) and to indicate the FIFI is ready on *either* FIFOREADY *or* DISABLED on ARMv8-M. ITM has been tested and verified on an ARMv7-M CPU (an STM32F407, a Cortex-M4) and an ARMv8-M CPU (an LPC55S69, a Cortex-M33).

Without this fix, any use of ITM will hang on ARMv8-M -- which may in fact be the root cause of #74...