### PR TITLE
make 'fn ptr()' APIs to be 'const fn ptr()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - New `InterruptNumber` trait is now required on interrupt arguments to the
   various NVIC functions, replacing the previous use of `Nr` from bare-metal.
+- Associated const `PTR` is introduced to Core Peripherals to
+  replace the existing `ptr()` API. `ptr()` API is to be removed in the
+  next breaking release (v0.7)
 
 ## [v0.6.2] - 2020-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New `InterruptNumber` trait is now required on interrupt arguments to the
   various NVIC functions, replacing the previous use of `Nr` from bare-metal.
 - Associated const `PTR` is introduced to Core Peripherals to
-  replace the existing `ptr()` API. `ptr()` API is to be removed in the
-  next breaking release (v0.7)
+  eventually replace the existing `ptr()` API.
 
 ## [v0.6.2] - 2020-01-12
 

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -231,7 +231,7 @@ unsafe impl Send for CBP {}
 #[cfg(not(armv6m))]
 impl CBP {
     #[inline(always)]
-    pub(crate) unsafe fn new() -> Self {
+    pub(crate) const unsafe fn new() -> Self {
         CBP {
             _marker: PhantomData,
         }
@@ -239,7 +239,7 @@ impl CBP {
 
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const self::cbp::RegisterBlock {
+    pub const fn ptr() -> *const self::cbp::RegisterBlock {
         0xE000_EF50 as *const _
     }
 }
@@ -264,7 +264,7 @@ unsafe impl Send for CPUID {}
 impl CPUID {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const self::cpuid::RegisterBlock {
+    pub const fn ptr() -> *const self::cpuid::RegisterBlock {
         0xE000_ED00 as *const _
     }
 }
@@ -288,7 +288,7 @@ unsafe impl Send for DCB {}
 impl DCB {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const dcb::RegisterBlock {
+    pub const fn ptr() -> *const dcb::RegisterBlock {
         0xE000_EDF0 as *const _
     }
 }
@@ -312,7 +312,7 @@ unsafe impl Send for DWT {}
 impl DWT {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const dwt::RegisterBlock {
+    pub const fn ptr() -> *const dwt::RegisterBlock {
         0xE000_1000 as *const _
     }
 }
@@ -337,7 +337,7 @@ unsafe impl Send for FPB {}
 impl FPB {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const fpb::RegisterBlock {
+    pub const fn ptr() -> *const fpb::RegisterBlock {
         0xE000_2000 as *const _
     }
 }
@@ -363,7 +363,7 @@ unsafe impl Send for FPU {}
 impl FPU {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const fpu::RegisterBlock {
+    pub const fn ptr() -> *const fpu::RegisterBlock {
         0xE000_EF30 as *const _
     }
 }
@@ -393,7 +393,7 @@ unsafe impl Send for ICB {}
 impl ICB {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *mut icb::RegisterBlock {
+    pub const fn ptr() -> *mut icb::RegisterBlock {
         0xE000_E004 as *mut _
     }
 }
@@ -425,7 +425,7 @@ unsafe impl Send for ITM {}
 impl ITM {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *mut itm::RegisterBlock {
+    pub const fn ptr() -> *mut itm::RegisterBlock {
         0xE000_0000 as *mut _
     }
 }
@@ -458,7 +458,7 @@ unsafe impl Send for MPU {}
 impl MPU {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const mpu::RegisterBlock {
+    pub const fn ptr() -> *const mpu::RegisterBlock {
         0xE000_ED90 as *const _
     }
 }
@@ -482,7 +482,7 @@ unsafe impl Send for NVIC {}
 impl NVIC {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const nvic::RegisterBlock {
+    pub const fn ptr() -> *const nvic::RegisterBlock {
         0xE000_E100 as *const _
     }
 }
@@ -507,7 +507,7 @@ unsafe impl Send for SAU {}
 impl SAU {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const sau::RegisterBlock {
+    pub const fn ptr() -> *const sau::RegisterBlock {
         0xE000_EDD0 as *const _
     }
 }
@@ -532,7 +532,7 @@ unsafe impl Send for SCB {}
 impl SCB {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const scb::RegisterBlock {
+    pub const fn ptr() -> *const scb::RegisterBlock {
         0xE000_ED04 as *const _
     }
 }
@@ -556,7 +556,7 @@ unsafe impl Send for SYST {}
 impl SYST {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const syst::RegisterBlock {
+    pub const fn ptr() -> *const syst::RegisterBlock {
         0xE000_E010 as *const _
     }
 }
@@ -581,7 +581,7 @@ unsafe impl Send for TPIU {}
 impl TPIU {
     /// Returns a pointer to the register block
     #[inline(always)]
-    pub fn ptr() -> *const tpiu::RegisterBlock {
+    pub const fn ptr() -> *const tpiu::RegisterBlock {
         0xE004_0000 as *const _
     }
 }

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -238,7 +238,7 @@ impl CBP {
     }
 
     /// Pointer to the register block
-    pub const CBP_PTR: *const self::cbp::RegisterBlock = 0xE000_EF50 as *const _;
+    pub const PTR: *const self::cbp::RegisterBlock = 0xE000_EF50 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -266,7 +266,7 @@ unsafe impl Send for CPUID {}
 
 impl CPUID {
     /// Pointer to the register block
-    pub const CPUID_PTR: *const self::cpuid::RegisterBlock = 0xE000_ED00 as *const _;
+    pub const PTR: *const self::cpuid::RegisterBlock = 0xE000_ED00 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -293,7 +293,7 @@ unsafe impl Send for DCB {}
 
 impl DCB {
     /// Pointer to the register block
-    pub const DCB_PTR: *const dcb::RegisterBlock = 0xE000_EDF0 as *const _;
+    pub const PTR: *const dcb::RegisterBlock = 0xE000_EDF0 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -320,7 +320,7 @@ unsafe impl Send for DWT {}
 
 impl DWT {
     /// Pointer to the register block
-    pub const DWT_PTR: *const dwt::RegisterBlock = 0xE000_1000 as *const _;
+    pub const PTR: *const dwt::RegisterBlock = 0xE000_1000 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -348,7 +348,7 @@ unsafe impl Send for FPB {}
 #[cfg(not(armv6m))]
 impl FPB {
     /// Pointer to the register block
-    pub const FPB_PTR: *const fpb::RegisterBlock = 0xE000_2000 as *const _;
+    pub const PTR: *const fpb::RegisterBlock = 0xE000_2000 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -377,7 +377,7 @@ unsafe impl Send for FPU {}
 #[cfg(any(has_fpu, target_arch = "x86_64"))]
 impl FPU {
     /// Pointer to the register block
-    pub const FPU_PTR: *const fpu::RegisterBlock = 0xE000_EF30 as *const _;
+    pub const PTR: *const fpu::RegisterBlock = 0xE000_EF30 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -410,7 +410,7 @@ unsafe impl Send for ICB {}
 
 impl ICB {
     /// Pointer to the register block
-    pub const ICB_PTR: *mut icb::RegisterBlock = 0xE000_E004 as *mut _;
+    pub const PTR: *mut icb::RegisterBlock = 0xE000_E004 as *mut _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -445,7 +445,7 @@ unsafe impl Send for ITM {}
 #[cfg(all(not(armv6m), not(armv8m_base)))]
 impl ITM {
     /// Pointer to the register block
-    pub const ITM_PTR: *mut itm::RegisterBlock = 0xE000_0000 as *mut _;
+    pub const PTR: *mut itm::RegisterBlock = 0xE000_0000 as *mut _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -481,7 +481,7 @@ unsafe impl Send for MPU {}
 
 impl MPU {
     /// Pointer to the register block
-    pub const MPU_PTR: *const mpu::RegisterBlock = 0xE000_ED90 as *const _;
+    pub const PTR: *const mpu::RegisterBlock = 0xE000_ED90 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -508,7 +508,7 @@ unsafe impl Send for NVIC {}
 
 impl NVIC {
     /// Pointer to the register block
-    pub const NVIC_PTR: *const nvic::RegisterBlock = 0xE000_E100 as *const _;
+    pub const PTR: *const nvic::RegisterBlock = 0xE000_E100 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -536,7 +536,7 @@ unsafe impl Send for SAU {}
 #[cfg(armv8m)]
 impl SAU {
     /// Pointer to the register block
-    pub const SAU_PTR: *const sau::RegisterBlock = 0xE000_EDD0 as *const _;
+    pub const PTR: *const sau::RegisterBlock = 0xE000_EDD0 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -564,7 +564,7 @@ unsafe impl Send for SCB {}
 
 impl SCB {
     /// Pointer to the register block
-    pub const SCB_PTR: *const scb::RegisterBlock = 0xE000_ED04 as *const _;
+    pub const PTR: *const scb::RegisterBlock = 0xE000_ED04 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -591,7 +591,7 @@ unsafe impl Send for SYST {}
 
 impl SYST {
     /// Pointer to the register block
-    pub const SYST_PTR: *const syst::RegisterBlock = 0xE000_E010 as *const _;
+    pub const PTR: *const syst::RegisterBlock = 0xE000_E010 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
@@ -619,7 +619,7 @@ unsafe impl Send for TPIU {}
 #[cfg(not(armv6m))]
 impl TPIU {
     /// Pointer to the register block
-    pub const TPIU_PTR: *const tpiu::RegisterBlock = 0xE004_0000 as *const _;
+    pub const PTR: *const tpiu::RegisterBlock = 0xE004_0000 as *const _;
 
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -237,7 +237,10 @@ impl CBP {
         }
     }
 
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const CBP_PTR: *const self::cbp::RegisterBlock = 0xE000_EF50 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const self::cbp::RegisterBlock {
         0xE000_EF50 as *const _
@@ -262,7 +265,10 @@ pub struct CPUID {
 unsafe impl Send for CPUID {}
 
 impl CPUID {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const CPUID_PTR: *const self::cpuid::RegisterBlock = 0xE000_ED00 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const self::cpuid::RegisterBlock {
         0xE000_ED00 as *const _
@@ -286,7 +292,10 @@ pub struct DCB {
 unsafe impl Send for DCB {}
 
 impl DCB {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const DCB_PTR: *const dcb::RegisterBlock = 0xE000_EDF0 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const dcb::RegisterBlock {
         0xE000_EDF0 as *const _
@@ -310,7 +319,10 @@ pub struct DWT {
 unsafe impl Send for DWT {}
 
 impl DWT {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const DWT_PTR: *const dwt::RegisterBlock = 0xE000_1000 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const dwt::RegisterBlock {
         0xE000_1000 as *const _
@@ -335,7 +347,10 @@ unsafe impl Send for FPB {}
 
 #[cfg(not(armv6m))]
 impl FPB {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const FPB_PTR: *const fpb::RegisterBlock = 0xE000_2000 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const fpb::RegisterBlock {
         0xE000_2000 as *const _
@@ -361,7 +376,10 @@ unsafe impl Send for FPU {}
 
 #[cfg(any(has_fpu, target_arch = "x86_64"))]
 impl FPU {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const FPU_PTR: *const fpu::RegisterBlock = 0xE000_EF30 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const fpu::RegisterBlock {
         0xE000_EF30 as *const _
@@ -391,7 +409,10 @@ pub struct ICB {
 unsafe impl Send for ICB {}
 
 impl ICB {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const ICB_PTR: *mut icb::RegisterBlock = 0xE000_E004 as *mut _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *mut icb::RegisterBlock {
         0xE000_E004 as *mut _
@@ -423,7 +444,10 @@ unsafe impl Send for ITM {}
 
 #[cfg(all(not(armv6m), not(armv8m_base)))]
 impl ITM {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const ITM_PTR: *mut itm::RegisterBlock = 0xE000_0000 as *mut _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *mut itm::RegisterBlock {
         0xE000_0000 as *mut _
@@ -456,7 +480,10 @@ pub struct MPU {
 unsafe impl Send for MPU {}
 
 impl MPU {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const MPU_PTR: *const mpu::RegisterBlock = 0xE000_ED90 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const mpu::RegisterBlock {
         0xE000_ED90 as *const _
@@ -480,7 +507,10 @@ pub struct NVIC {
 unsafe impl Send for NVIC {}
 
 impl NVIC {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const NVIC_PTR: *const nvic::RegisterBlock = 0xE000_E100 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const nvic::RegisterBlock {
         0xE000_E100 as *const _
@@ -505,7 +535,10 @@ unsafe impl Send for SAU {}
 
 #[cfg(armv8m)]
 impl SAU {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const SAU_PTR: *const sau::RegisterBlock = 0xE000_EDD0 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const sau::RegisterBlock {
         0xE000_EDD0 as *const _
@@ -530,7 +563,10 @@ pub struct SCB {
 unsafe impl Send for SCB {}
 
 impl SCB {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const SCB_PTR: *const scb::RegisterBlock = 0xE000_ED04 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const scb::RegisterBlock {
         0xE000_ED04 as *const _
@@ -554,7 +590,10 @@ pub struct SYST {
 unsafe impl Send for SYST {}
 
 impl SYST {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const SYST_PTR: *const syst::RegisterBlock = 0xE000_E010 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const syst::RegisterBlock {
         0xE000_E010 as *const _
@@ -579,7 +618,10 @@ unsafe impl Send for TPIU {}
 
 #[cfg(not(armv6m))]
 impl TPIU {
-    /// Returns a pointer to the register block
+    /// Pointer to the register block
+    pub const TPIU_PTR: *const tpiu::RegisterBlock = 0xE004_0000 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const tpiu::RegisterBlock {
         0xE004_0000 as *const _

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -243,7 +243,7 @@ impl CBP {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const self::cbp::RegisterBlock {
-        0xE000_EF50 as *const _
+        Self::PTR
     }
 }
 
@@ -253,7 +253,7 @@ impl ops::Deref for CBP {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -271,7 +271,7 @@ impl CPUID {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const self::cpuid::RegisterBlock {
-        0xE000_ED00 as *const _
+        Self::PTR
     }
 }
 
@@ -280,7 +280,7 @@ impl ops::Deref for CPUID {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -298,7 +298,7 @@ impl DCB {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const dcb::RegisterBlock {
-        0xE000_EDF0 as *const _
+        Self::PTR
     }
 }
 
@@ -307,7 +307,7 @@ impl ops::Deref for DCB {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*DCB::ptr() }
+        unsafe { &*DCB::PTR }
     }
 }
 
@@ -325,7 +325,7 @@ impl DWT {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const dwt::RegisterBlock {
-        0xE000_1000 as *const _
+        Self::PTR
     }
 }
 
@@ -334,7 +334,7 @@ impl ops::Deref for DWT {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -353,7 +353,7 @@ impl FPB {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const fpb::RegisterBlock {
-        0xE000_2000 as *const _
+        Self::PTR
     }
 }
 
@@ -363,7 +363,7 @@ impl ops::Deref for FPB {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -382,7 +382,7 @@ impl FPU {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const fpu::RegisterBlock {
-        0xE000_EF30 as *const _
+        Self::PTR
     }
 }
 
@@ -392,7 +392,7 @@ impl ops::Deref for FPU {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -415,7 +415,7 @@ impl ICB {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *mut icb::RegisterBlock {
-        0xE000_E004 as *mut _
+        Self::PTR
     }
 }
 
@@ -424,14 +424,14 @@ impl ops::Deref for ICB {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
 impl ops::DerefMut for ICB {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *Self::ptr() }
+        unsafe { &mut *Self::PTR }
     }
 }
 
@@ -450,7 +450,7 @@ impl ITM {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *mut itm::RegisterBlock {
-        0xE000_0000 as *mut _
+        Self::PTR
     }
 }
 
@@ -460,7 +460,7 @@ impl ops::Deref for ITM {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -468,7 +468,7 @@ impl ops::Deref for ITM {
 impl ops::DerefMut for ITM {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *Self::ptr() }
+        unsafe { &mut *Self::PTR }
     }
 }
 
@@ -486,7 +486,7 @@ impl MPU {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const mpu::RegisterBlock {
-        0xE000_ED90 as *const _
+        Self::PTR
     }
 }
 
@@ -495,7 +495,7 @@ impl ops::Deref for MPU {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -513,7 +513,7 @@ impl NVIC {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const nvic::RegisterBlock {
-        0xE000_E100 as *const _
+        Self::PTR
     }
 }
 
@@ -522,7 +522,7 @@ impl ops::Deref for NVIC {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -541,7 +541,7 @@ impl SAU {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const sau::RegisterBlock {
-        0xE000_EDD0 as *const _
+        Self::PTR
     }
 }
 
@@ -551,7 +551,7 @@ impl ops::Deref for SAU {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -569,7 +569,7 @@ impl SCB {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const scb::RegisterBlock {
-        0xE000_ED04 as *const _
+        Self::PTR
     }
 }
 
@@ -578,7 +578,7 @@ impl ops::Deref for SCB {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -596,7 +596,7 @@ impl SYST {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const syst::RegisterBlock {
-        0xE000_E010 as *const _
+        Self::PTR
     }
 }
 
@@ -605,7 +605,7 @@ impl ops::Deref for SYST {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }
 
@@ -624,7 +624,7 @@ impl TPIU {
     /// Returns a pointer to the register block (to be deprecated in 0.7)
     #[inline(always)]
     pub const fn ptr() -> *const tpiu::RegisterBlock {
-        0xE004_0000 as *const _
+        Self::PTR
     }
 }
 
@@ -634,6 +634,6 @@ impl ops::Deref for TPIU {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::ptr() }
+        unsafe { &*Self::PTR }
     }
 }


### PR DESCRIPTION
This PR changes functions like `ITM::ptr()`, `DWT::ptr()` to become `const fn`s.

* functions like `ITM::ptr()`, `DWT::ptr()` return pointers that are cast from constants,
but currently these functions can't be used to define a constant. This PR will allow below code to compile.
```rust
use cortex_m::peripheral::ITM;
use cortex_m::peripheral::itm::RegisterBlock;
// Below line currently won't compile, since `ITM::ptr()` is not a `const fn`
const ITM_PTR: *mut RegisterBlock = ITM::ptr();
```

I couldn't think of disadvantages that might accompany this change, but please correct me if I'm wrong.
Thank you for reviewing this PR :+1: 
