### PR TITLE
Always link pre-built asm, required for new cache management functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let name = env::var("CARGO_PKG_NAME").unwrap();
 
-    if target.starts_with("thumb") && env::var_os("CARGO_FEATURE_INLINE_ASM").is_none() {
+    if target.starts_with("thumb") {
         fs::copy(
             format!("bin/{}.a", target),
             out_dir.join(format!("lib{}.a", name)),


### PR DESCRIPTION
In #234 we added new `__enable_icache` and `__enable_dcache` assembly routines, but without providing an inline assembly version, to reduce duplication and since there wasn't an expected performance impact. However, our build.rs currently only links the pre-built object if the `inline-asm` feature is disabled, which means currently you can't call `enable_icache()` and use `inline-asm` at the same time.

This PR makes us always link against the pre-built objects (for thumb targets) even if `inline-asm` is used; the pre-built object would only be used for the cache management routines at present but we may want to put more routines into the assembly blob only in the future.

Closes #245.