### PR TITLE
Correct typo in RASR register aliases

### DIFF
--- a/src/peripheral/mpu.rs
+++ b/src/peripheral/mpu.rs
@@ -18,16 +18,16 @@ pub struct RegisterBlock {
     pub rasr: RW<u32>,
     /// Alias 1 of RBAR
     pub rbar_a1: RW<u32>,
-    /// Alias 1 of RSAR
-    pub rsar_a1: RW<u32>,
+    /// Alias 1 of RASR
+    pub rasr_a1: RW<u32>,
     /// Alias 2 of RBAR
     pub rbar_a2: RW<u32>,
-    /// Alias 2 of RSAR
-    pub rsar_a2: RW<u32>,
+    /// Alias 2 of RASR
+    pub rasr_a2: RW<u32>,
     /// Alias 3 of RBAR
     pub rbar_a3: RW<u32>,
-    /// Alias 3 of RSAR
-    pub rsar_a3: RW<u32>,
+    /// Alias 3 of RASR
+    pub rasr_a3: RW<u32>,
 }
 
 /// Register block for ARMv8-M

--- a/src/peripheral/test.rs
+++ b/src/peripheral/test.rs
@@ -100,11 +100,11 @@ fn mpu() {
     assert_eq!(address(&mpu.rbar), 0xE000ED9C);
     assert_eq!(address(&mpu.rasr), 0xE000EDA0);
     assert_eq!(address(&mpu.rbar_a1), 0xE000EDA4);
-    assert_eq!(address(&mpu.rsar_a1), 0xE000EDA8);
+    assert_eq!(address(&mpu.rasr_a1), 0xE000EDA8);
     assert_eq!(address(&mpu.rbar_a2), 0xE000EDAC);
-    assert_eq!(address(&mpu.rsar_a2), 0xE000EDB0);
+    assert_eq!(address(&mpu.rasr_a2), 0xE000EDB0);
     assert_eq!(address(&mpu.rbar_a3), 0xE000EDB4);
-    assert_eq!(address(&mpu.rsar_a3), 0xE000EDB8);
+    assert_eq!(address(&mpu.rasr_a3), 0xE000EDB8);
 }
 
 #[test]


### PR DESCRIPTION
Fixes the typo in the a1, a2, and a3 aliases of the RASR MPU register.