### PR TITLE
Fix warnings

### DIFF
--- a/src/peripheral/icb.rs
+++ b/src/peripheral/icb.rs
@@ -1,6 +1,8 @@
 //! Implementation Control Block
 
-use volatile_register::{RO, RW};
+#[cfg(any(armv7m, armv8m, target_arch = "x86_64"))]
+use volatile_register::RO;
+use volatile_register::RW;
 
 /// Register block
 #[repr(C)]

--- a/src/register/fpscr.rs
+++ b/src/register/fpscr.rs
@@ -148,10 +148,10 @@ impl Fpscr {
     pub fn set_rmode(&mut self, rmode: RMode) {
         let mask = 3 << 22;
         match rmode {
-            RMode::Nearest => self.bits = self.bits & !mask,
+            RMode::Nearest => self.bits &= !mask,
             RMode::PlusInfinity => self.bits = (self.bits & !mask) | (1 << 22),
             RMode::MinusInfinity => self.bits = (self.bits & !mask) | (2 << 22),
-            RMode::Zero => self.bits = self.bits | mask,
+            RMode::Zero => self.bits |= mask,
         }
     }
 


### PR DESCRIPTION
This was causing CI to fail when using `-D warnings`.