### PR TITLE
Clean up some unsafe code introduced by #202

### DIFF
--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -339,7 +339,9 @@ impl SCB {
         // NOTE(unsafe): The asm routine manages exclusive access to the SCB
         // registers and applies the proper barriers; it is technically safe on
         // its own, and is only `unsafe` here because it's `extern "C"`.
-        unsafe { __enable_icache(); }
+        unsafe {
+            __enable_icache();
+        }
     }
 
     /// Disables I-cache if currently enabled.
@@ -412,7 +414,9 @@ impl SCB {
         // NOTE(unsafe): The asm routine manages exclusive access to the SCB
         // registers and applies the proper barriers; it is technically safe on
         // its own, and is only `unsafe` here because it's `extern "C"`.
-        unsafe { __enable_dcache(); }
+        unsafe {
+            __enable_dcache();
+        }
     }
 
     /// Disables D-cache if currently enabled.
@@ -952,28 +956,19 @@ impl SCB {
     /// [`NVIC.get_priority`](struct.NVIC.html#method.get_priority) for more details.
     #[inline]
     pub fn get_priority(system_handler: SystemHandler) -> u8 {
-        let index = system_handler as u8;
+        // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
+        let index = system_handler.clone() as u8;
 
         #[cfg(not(armv6m))]
         {
             // NOTE(unsafe) atomic read with no side effects
-
-            // NOTE(unsafe): Index is bounded to [4,15] by SystemHandler design.
-            // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
-            let priority_ref = unsafe {(*Self::ptr()).shpr.get_unchecked(usize::from(index - 4))};
-
-            priority_ref.read()
+            unsafe { (*Self::ptr()).shpr[usize::from(index - 4)].read() }
         }
 
         #[cfg(armv6m)]
         {
             // NOTE(unsafe) atomic read with no side effects
-
-            // NOTE(unsafe): Index is bounded to [11,15] by SystemHandler design.
-            // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
-            let priority_ref = unsafe {(*Self::ptr()).shpr.get_unchecked(usize::from((index - 8) / 4))};
-
-            let shpr = priority_ref.read();
+            let shpr = unsafe { (*Self::ptr()).shpr[usize::from((index - 8) / 4)].read() };
             let prio = (shpr >> (8 * (index % 4))) & 0x0000_00ff;
             prio as u8
         }
@@ -993,24 +988,18 @@ impl SCB {
     /// [`register::basepri`](../register/basepri/index.html)) and compromise memory safety.
     #[inline]
     pub unsafe fn set_priority(&mut self, system_handler: SystemHandler, prio: u8) {
-        let index = system_handler as u8;
+        // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
+        let index = system_handler.clone() as u8;
 
         #[cfg(not(armv6m))]
         {
-            // NOTE(unsafe): Index is bounded to [4,15] by SystemHandler design.
-            // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
-            let priority_ref = (*Self::ptr()).shpr.get_unchecked(usize::from(index - 4));
-
-            priority_ref.write(prio)
+            self.shpr[usize::from(index - 4)].write(prio)
         }
 
         #[cfg(armv6m)]
         {
             // NOTE(unsafe): Index is bounded to [11,15] by SystemHandler design.
-            // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
-            let priority_ref = (*Self::ptr()).shpr.get_unchecked(usize::from((index - 8) / 4));
-
-            priority_ref.modify(|value| {
+            self.shpr[usize::from((index - 8) / 4)].modify(|value| {
                 let shift = 8 * (index % 4);
                 let mask = 0x0000_00ff << shift;
                 let prio = u32::from(prio) << shift;


### PR DESCRIPTION
Although I haven't checked these exact functions, a simple clone seems to be enough to elide the bounds checks: https://godbolt.org/z/a1jb4h (`access` taken directly from [the issue](https://github.com/rust-lang/rust/issues/13926)).