### PR TITLE
Add embedded targets to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,17 @@ bare-metal = { version = "0.2.0", features = ["const-fn"] }
 volatile-register = "0.2.0"
 bitfield = "0.13.2"
 
+[package.metadata.docs.rs]
+targets = [
+    "thumbv8m.main-none-eabihf",
+    "thumbv6m-none-eabi",
+    "thumbv7em-none-eabi",
+    "thumbv7em-none-eabihf",
+    "thumbv7m-none-eabi",
+    "thumbv8m.base-none-eabi",
+    "thumbv8m.main-none-eabi"
+]
+
 [features]
 cm7-r0p1 = []
 inline-asm = []


### PR DESCRIPTION
Some modules of this repo are gated by the various targets and hence docs.rs does not show the documentation for them! Like the Armv8-M ones for [example](https://github.com/rust-embedded/cortex-m/issues/217#issuecomment-661039292) and the `cmse` module.

docs.rs now allows building for specific target and since [this PR](https://github.com/rust-lang/docs.rs/pull/633) even for targets available via `rustup`!

The `stm32f3_discovery` crate does it, look at ["Platform" on docs.rs](https://docs.rs/stm32f3-discovery/0.4.0/stm32f3_discovery/index.html).

So I think it would be very neat to have on `cortex-m` and I proposing to add the following targets. The first one will show by default, I choosed the latest and greatest for that 😄 

I tested locally with `cargo doc --target ...` for all of them.