### PR TITLE
Remove outdated TODO

### DIFF
--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -55,8 +55,6 @@
 //!
 //! - ARMv7-M Architecture Reference Manual (Issue E.b) - Chapter B3
 
-// TODO stand-alone register: STIR
-
 use core::marker::PhantomData;
 use core::ops;
 

--- a/src/peripheral/nvic.rs
+++ b/src/peripheral/nvic.rs
@@ -79,9 +79,11 @@ impl NVIC {
     ///
     /// Writing a value to the INTID field is the same as manually pending an interrupt by setting
     /// the corresponding interrupt bit in an Interrupt Set Pending Register. This is similar to
-    /// `set_pending`.
+    /// [`NVIC::pend`].
     ///
     /// This method is not available on ARMv6-M chips.
+    ///
+    /// [`NVIC::pend`]: #method.pend
     #[cfg(not(armv6m))]
     #[inline]
     pub fn request<I>(&mut self, interrupt: I)


### PR DESCRIPTION
STIR has been wrapped in the NVIC (it isn't standalone)