### PR TITLE
Implement InterruptNumber for bare_metal::Nr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - New `InterruptNumber` trait is now required on interrupt arguments to the
   various NVIC functions, replacing the previous use of `Nr` from bare-metal.
+  For backwards compatibility, `InterruptNumber` is implemented for types
+  which are `Nr + Copy`, but this will be removed in a future version.
 - Associated const `PTR` is introduced to Core Peripherals to
   eventually replace the existing `ptr()` API.
 - A delay driver based on SysTick.

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,6 +1,6 @@
 //! Interrupts
 
-pub use bare_metal::{CriticalSection, Mutex};
+pub use bare_metal::{CriticalSection, Mutex, Nr};
 
 /// Trait for enums of external interrupt numbers.
 ///
@@ -21,6 +21,15 @@ pub unsafe trait InterruptNumber: Copy {
     ///
     /// See trait documentation for safety requirements.
     fn number(self) -> u16;
+}
+
+/// Implement InterruptNumber for the old bare_metal::Nr trait.
+/// This implementation is for backwards compatibility only and will be removed in cortex-m 0.8.
+#[deprecated(since="0.7.0", note="Please update your PAC to one using the latest svd2rust")]
+unsafe impl<T: Nr + Copy> InterruptNumber for T {
+    fn number(self) -> u16 {
+        self.nr() as u16
+    }
 }
 
 /// Disables all interrupts


### PR DESCRIPTION
This PR aims to help backwards compatibility by implementing the new `InterruptNumber` trait (coming in cortex-m 0.7) for the old `bare_metal::Nr` trait. With this included in cortex-m 0.7, existing PACs generated from the current svd2rust (0.17) will work with cortex-m 0.7, and new PACs generated from a to-be-released svd2rust which uses `InterruptNumber directly will also work.

We can then remove this implementation in cortex-m 0.8 and upgrade cortex-m to depend on bare-metal 1.0 (or not depend on it at all) at that time.

With this PR in place, the upgrade path looks like:

* We release cortex-m 0.7, which users can upgrade to without needing a new PAC
* We release svd2rust 0.18, which will generate new PACs
* PACs update, now requiring cortex-m 0.7
* Users can update their PAC so long as they've already upgraded to cortex-m 0.7
* For cortex-m 0.8, we drop this impl and move off bare-metal 0.2, and a new PAC is required to use 0.8 onwards