### PR TITLE
Merge HStdout and HStderr into the same type

### DIFF
--- a/cortex-m-semihosting/CHANGELOG.md
+++ b/cortex-m-semihosting/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Merge `HStdout` and `HStderr` into one type: `HostStream`
+
 ## [v0.3.5] - 2019-08-29
 
 ### Added

--- a/cortex-m-semihosting/src/export.rs
+++ b/cortex-m-semihosting/src/export.rs
@@ -4,9 +4,9 @@ use core::fmt::{self, Write};
 
 use cortex_m::interrupt;
 
-use crate::hio::{self, HStderr, HStdout};
+use crate::hio::{self, HostStream};
 
-static mut HSTDOUT: Option<HStdout> = None;
+static mut HSTDOUT: Option<HostStream> = None;
 
 pub fn hstdout_str(s: &str) {
     let _result = interrupt::free(|_| unsafe {
@@ -28,7 +28,7 @@ pub fn hstdout_fmt(args: fmt::Arguments) {
     });
 }
 
-static mut HSTDERR: Option<HStderr> = None;
+static mut HSTDERR: Option<HostStream> = None;
 
 pub fn hstderr_str(s: &str) {
     let _result = interrupt::free(|_| unsafe {

--- a/cortex-m-semihosting/src/lib.rs
+++ b/cortex-m-semihosting/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! # Example
 //!
-//! ## Using `hio::HStdout`
+//! ## Using `hio::hstdout`
 //!
 //! This example will demonstrate how to print formatted strings.
 //!
@@ -35,11 +35,7 @@
 //!
 //! // This function will be called by the application
 //! fn print() -> Result<(), core::fmt::Error> {
-//!     let mut stdout = match hio::hstdout() {
-//!         Ok(fd) => fd,
-//!         Err(()) => return Err(core::fmt::Error),
-//!     };
-//!
+//!     let mut stdout = hio::hstdout().map_err(|_| core::fmt::Error)?;
 //!     let language = "Rust";
 //!     let ranking = 1;
 //!


### PR DESCRIPTION
As the next step in https://github.com/rust-embedded/cortex-m/pull/263#pullrequestreview-495095345, this PR applies https://github.com/rust-embedded/cortex-m-semihosting/pull/41 to this repository.

@m-ou-se, I tried exporting a patch from cortex-m-semihosting and applying it here but it didn't work first time, so I ended up just copying the changes. I've set you as the author of the commit and marked it as committed-by me, I hope you're OK with that but please let me know if you'd like it changed. (Also, thanks again for the PR, sorry it's taken over a year...).