### PR TITLE
Prepare for release of new versions of cortex-m-semihosting and panic-semihosting

### DIFF
--- a/cortex-m-semihosting/CHANGELOG.md
+++ b/cortex-m-semihosting/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.4.0] - 2020-10-14
+
+- Moved into cortex-m repository
 - Merge `HStdout` and `HStderr` into one type: `HostStream`
+- Support cortex-m v0.7
 
 ## [v0.3.5] - 2019-08-29
 
@@ -111,7 +115,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.5...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.4.0...HEAD
+[v0.4.0]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.3.5...c-m-sh-v0.4.0
 [v0.3.5]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.4...v0.3.5
 [v0.3.4]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.3...v0.3.4
 [v0.3.3]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.2...v0.3.3

--- a/cortex-m-semihosting/Cargo.toml
+++ b/cortex-m-semihosting/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-semihosting"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2018"
 
 [features]
@@ -19,4 +19,4 @@ jlink-quirks = []
 no-semihosting = []
 
 [dependencies]
-cortex-m = { path = "..", version = ">= 0.5.8, < 0.7" }
+cortex-m = { path = "..", version = ">= 0.5.8, < 0.8" }

--- a/panic-semihosting/CHANGELOG.md
+++ b/panic-semihosting/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.4] - 2020-10-14
+
+- Moved into cortex-m repository
+- Support cortex-m v0.7, cortex-m-semihosting v0.4
+
 ## [v0.5.3] - 2019-09-01
 
 - Added feature `jlink-quirks` to work with JLink
@@ -56,7 +61,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/p-sh-v0.5.4...HEAD
+[v0.5.4]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.5.3...p-sh-v0.5.4
 [v0.5.3]: https://github.com/rust-embedded/panic-semihosting/compare/v0.5.2...v0.5.3
 [v0.5.2]: https://github.com/rust-embedded/panic-semihosting/compare/v0.5.1...v0.5.2
 [v0.5.1]: https://github.com/rust-embedded/panic-semihosting/compare/v0.5.0...v0.5.1

--- a/panic-semihosting/Cargo.toml
+++ b/panic-semihosting/Cargo.toml
@@ -10,11 +10,11 @@ keywords = ["panic-handler", "panic-impl", "panic", "semihosting"]
 license = "MIT OR Apache-2.0"
 name = "panic-semihosting"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.5.3"
+version = "0.5.4"
 
 [dependencies]
-cortex-m = { path = "..", version = ">= 0.5.6, < 0.7" }
-cortex-m-semihosting = { path = "../cortex-m-semihosting", version = "0.3" }
+cortex-m = { path = "..", version = ">= 0.5.6, < 0.8" }
+cortex-m-semihosting = { path = "../cortex-m-semihosting", version = ">= 0.3, < 0.5" }
 
 [features]
 exit = []


### PR DESCRIPTION
For the next step in https://github.com/rust-embedded/cortex-m/pull/263#pullrequestreview-495095345, this PR increases the version number for panic-semihosting and cortex-m-semihosting. For c-m-sh this is a breaking change to include #269.

Both projects seem to build just fine with cortex-m master, so I anticipate they should work fine with the to-be-released 0.7, hence increasing the acceptable cortex-m version range.

The CHANGELOG links are a bit troublesome, so I've added new tags to this repo `c-m-sh-v0.3.5` and `p-sh-v0.5.3` which point to the merge commit, and I'll tag new `c-m-sh-v0.4.0` and `p-sh-v0.5.4` after this is merged.