### PR TITLE
Drop AT&T syntax from inline asm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,22 +26,22 @@ matrix:
 
     # MSRV
     - env: TARGET=thumbv6m-none-eabi
-      rust: 1.31.0
+      rust: 1.36.0
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     # MSRV
     - env: TARGET=thumbv7m-none-eabi
-      rust: 1.31.0
+      rust: 1.36.0
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     # MSRV
     - env: TARGET=thumbv7em-none-eabi
-      rust: 1.31.0
+      rust: 1.36.0
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     # MSRV
     - env: TARGET=thumbv7em-none-eabihf
-      rust: 1.31.0
+      rust: 1.36.0
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv6m-none-eabi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- MSRV bumped to 1.36.0 due to `aligned` dependency.
+
+### Fixed
+
+- Drop AT&T syntax from inline asm, which was causing miscompilations with newer versions of the compiler.
+
 ## [v0.6.3] - 2020-07-20
 
 ### Added

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -38,7 +38,7 @@ pub fn delay(_n: u32) {
         () => unsafe {
             llvm_asm!("1:
                   nop
-                  subs $0, $$1
+                  subs $0, #1
                   bne.n 1b"
                  : "+r"(_n / 4 + 1)
                  :
@@ -80,7 +80,6 @@ pub fn nop() {
         () => unimplemented!(),
     }
 }
-
 
 /// Generate an Undefined Instruction exception.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.31 and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.36 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 
 #![cfg_attr(feature = "inline-asm", feature(llvm_asm))]
@@ -34,7 +34,6 @@
 #![no_std]
 #![allow(clippy::identity_op)]
 #![allow(clippy::missing_safety_doc)]
-
 // This makes clippy warn about public functions which are not #[inline].
 //
 // Almost all functions in this crate result in trivial or even no assembly.


### PR DESCRIPTION
This was breaking compilation on thumbv6 targets and miscompiling on thumbv7.

Fixes #272 
Fixes #267 