### PR TITLE
Prepare for v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   See the `asm/lib.rs` documentation for more details.
 - Initial ARMv8-M MPU support
 - ICTR and ACTLR registers added
+- Support for the Security Attribution Unit on ARMv8-M
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.7.0] - 2020-11-09
+
 ### Added
 
 - New `InterruptNumber` trait is now required on interrupt arguments to the
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - A delay driver based on SysTick.
 - You can now use LTO to inline assembly calls, even on stable Rust.
   See the `asm/lib.rs` documentation for more details.
+- Initial ARMv8-M MPU support
+- ICTR and ACTLR registers added
 
 ### Changed
 
@@ -27,6 +31,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   technique which generates Rust static libs for stable calling, and uses the
   new `asm!` macro with `inline-asm`. See the `asm/lib.rs` documentation for
   more details.
+- Cache enabling now uses an assembly sequence to ensure correctness.
+- `ptr()` methods are now `const`.
+
+### Breaking Changes
+- `SCB::invalidate_dcache` and related methods are now unsafe, see #188
+- `Peripherals` struct is now non-exhaustive, so fields may be added in future
+  non-breaking changes
+- Removed `aligned` dependency
+- Removed const-fn feature
+- Removed previously deprecated APIs
+    - `NVIC::clear_pending`
+    - `NVIC::disable`
+    - `NVIC::enable`
+    - `NVIC::set_pending`
+    - `SCB::system_reset`
+- Removed `basepri`, `basepri_max`, and `faultmask` registers from thumbv8m.base
+
+## [v0.6.4] - 2020-10-26
+
+### Changed
+
+- MSRV bumped to 1.36.0 due to `aligned` dependency.
+
+### Fixed
+
+- Drop AT&T syntax from inline asm, which was causing miscompilations with newer versions of the compiler.
 
 ## [v0.6.3] - 2020-07-20
 
@@ -610,7 +640,9 @@ fn main() {
 - Functions to get the vector table
 - Wrappers over miscellaneous instructions like `bkpt`
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.6.3...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.0...HEAD
+[v0.7.0]: https://github.com/rust-embedded/cortex-m/compare/v0.6.4...v0.7.0
+[v0.6.4]: https://github.com/rust-embedded/cortex-m/compare/v0.6.3...v0.6.4
 [v0.6.3]: https://github.com/rust-embedded/cortex-m/compare/v0.6.2...v0.6.3
 [v0.6.2]: https://github.com/rust-embedded/cortex-m/compare/v0.6.1...v0.6.2
 [v0.6.1]: https://github.com/rust-embedded/cortex-m/compare/v0.6.0...v0.6.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2018"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -25,10 +25,6 @@ pub unsafe trait InterruptNumber: Copy {
 
 /// Implement InterruptNumber for the old bare_metal::Nr trait.
 /// This implementation is for backwards compatibility only and will be removed in cortex-m 0.8.
-#[deprecated(
-    since = "0.7.0",
-    note = "Please update your PAC to one using the latest svd2rust"
-)]
 unsafe impl<T: Nr + Copy> InterruptNumber for T {
     #[inline]
     fn number(self) -> u16 {


### PR DESCRIPTION
I think I got everything in the changelog updates but please point out anything I missed. Anything else missing before we're ready for 0.7.0?

Note that my plan is to now release cortex-m-semihosting 0.3.6 (with support for cortex-m >0.5&&<0.8) and 0.4.2 (cortex-m ^0.7, with our recent breaking changes) _after_ cortex-m 0.7 is out.