### PR TITLE
Deprecate msp::write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New assembly methods `asm::semihosting_syscall`, `asm::bootstrap`, and
   `asm::bootload`.
 
+### Changed
+
+- `msp::write` has been deprecated in favor of `asm::bootstrap`. It was not
+  possible to use `msp::write` without causing Undefined Behavior, so all
+  existing users are encouraged to migrate.
+
 ## [v0.7.0] - 2020-11-09
 
 ### Added

--- a/src/register/msp.rs
+++ b/src/register/msp.rs
@@ -8,6 +8,7 @@ pub fn read() -> u32 {
 
 /// Writes `bits` to the CPU register
 #[inline]
+#[deprecated = "calling this function invokes Undefined Behavior"]
 pub unsafe fn write(bits: u32) {
     call_asm!(__msp_w(bits: u32));
 }


### PR DESCRIPTION
The function can not be used from Rust code, because it destroys the stack frame.

Users must use an assembly block (inline or out-of-line) that both sets MSP and performs a method call.