### PR TITLE
Try scheduling CI runs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,31 @@
+on:
+  schedule:
+    # Run every week at 7pm UTC Wednesday.
+    - cron: '0 19 * * WED'
+
+name: Cron CI
+
+jobs:
+  ci-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run tests
+        run: cargo test --all
+      - name: Deliberate failure to test issue opening
+        run: false
+      - uses: imjohnbo/issue-bot@v2
+        if: failure()
+        with:
+          title: CI Failure
+          body: |
+            Scheduled CI run failed. Details:
+
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a first go at running CI jobs on a scheduled basis. This job will run at 7pm UTC today (Wednesday), run our tests, and, in this case, fail. On failure it should then open a new issue on the repository with a link to the failed CI job.

We can bikeshed the schedule (this is just to get it to run soonish), and obviously I'll do another PR to remove the failing step once we've checked it works.

Please don't merge if we miss 7pm weds; I'll update the schedule first.