### PR TITLE
Update c-m-sh changelog for 0.3.6

### DIFF
--- a/cortex-m-semihosting/CHANGELOG.md
+++ b/cortex-m-semihosting/CHANGELOG.md
@@ -15,6 +15,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Merge `HStdout` and `HStderr` into one type: `HostStream`
 - Support cortex-m v0.7
 
+## [v0.3.6] - 2020-12-01
+
+### Added
+
+- Update cortex-m dependency to support version 0.7.
+- Add `no-semihosting` feature to disable all semihosting calls.
+
 ## [v0.3.5] - 2019-08-29
 
 ### Added
@@ -122,6 +129,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Unreleased]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.4.1...HEAD
 [v0.4.1]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.4.0...c-m-sh-v0.4.1
 [v0.4.0]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.3.5...c-m-sh-v0.4.0
+[v0.3.6]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.5...v0.3.6
 [v0.3.5]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.4...v0.3.5
 [v0.3.4]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.3...v0.3.4
 [v0.3.3]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.2...v0.3.3


### PR DESCRIPTION
Copied from https://github.com/rust-embedded/cortex-m-semihosting/pull/61