### PR TITLE
Add required 'labels' field to scheduled CI, update next run date

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,7 +1,7 @@
 on:
   schedule:
-    # Run every week at 7pm UTC Wednesday.
-    - cron: '0 19 * * WED'
+    # Run every week at 10pm UTC Tuesday.
+    - cron: '0 22 * * TUE'
 
 name: Cron CI
 
@@ -23,6 +23,7 @@ jobs:
         if: failure()
         with:
           title: CI Failure
+          labels: ci
           body: |
             Scheduled CI run failed. Details:
 


### PR DESCRIPTION
See also #298. This should fail at 10pm today _and open an issue this time_, then we'll update it to remove the intentional failure and perhaps set the scheduled date to something more useful.