### PR TITLE
Finish setting up scheduled CI job

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,7 +1,7 @@
 on:
   schedule:
-    # Run every week at 10pm UTC Tuesday.
-    - cron: '0 22 * * TUE'
+    # Run every week at 8am UTC Saturday.
+    - cron: '0 8 * * SAT'
 
 name: Cron CI
 
@@ -17,8 +17,6 @@ jobs:
           override: true
       - name: Run tests
         run: cargo test --all
-      - name: Deliberate failure to test issue opening
-        run: false
       - uses: imjohnbo/issue-bot@v2
         if: failure()
         with:


### PR DESCRIPTION
The scheduled CI seems to have worked (#306), so this PR removes the forced failure and sets the time to a hopefully sensible saturday morning, though I suppose it doesn't really matter that much what time of week it is.