### PR TITLE
Prepare for v0.6.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.6.5] - 2021-01-13
+## [v0.6.5] - 2021-01-24
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.6.5-alpha"
+version = "0.6.5"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
From testing it seems like 0.6.5-alpha is OK, but it's really hard to use because you have to patch every dependency (HAL, PAC, etc) that's trying to use 0.6. I think the sooner we get the actual release out the better, now.