### PR TITLE
Prepare for v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.7.1] - 2021-01-25
+
 ### Added
 
 - New assembly methods `asm::semihosting_syscall`, `asm::bootstrap`, and
@@ -668,8 +670,10 @@ fn main() {
 - Functions to get the vector table
 - Wrappers over miscellaneous instructions like `bkpt`
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.1...HEAD
+[v0.7.1]: https://github.com/rust-embedded/cortex-m/compare/v0.7.0...v0.7.1
 [v0.7.0]: https://github.com/rust-embedded/cortex-m/compare/v0.6.4...v0.7.0
+[v0.6.5]: https://github.com/rust-embedded/cortex-m/compare/v0.6.4...v0.6.5
 [v0.6.4]: https://github.com/rust-embedded/cortex-m/compare/v0.6.3...v0.6.4
 [v0.6.3]: https://github.com/rust-embedded/cortex-m/compare/v0.6.2...v0.6.3
 [v0.6.2]: https://github.com/rust-embedded/cortex-m/compare/v0.6.1...v0.6.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
 


### PR DESCRIPTION
Includes:

* Deprecate msp::write #297
* New syscall and bootstrap ASM #299 
* More compiler fences #311 
* asm::delay timing fix #312 
* asm::delay clobber fix #317 
* LTO for ASM fix #318 

Doesn't include anything to help with #304 which might be nice to fix but can come in 0.7.2 and might need some time to think about.