### PR TITLE
Fix missing peripheral::itm export, prepare v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.6.7] - 2021-01-26
+
+### Fixed
+
+- Fixed missing `peripheral::itm` reexport.
+
 ## [v0.6.6] - 2021-01-26
 
 ### Fixed
@@ -613,7 +619,8 @@ fn main() {
 - Functions to get the vector table
 - Wrappers over miscellaneous instructions like `bkpt`
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.6.6...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.6.7...HEAD
+[v0.6.6]: https://github.com/rust-embedded/cortex-m/compare/v0.6.6...v0.6.7
 [v0.6.6]: https://github.com/rust-embedded/cortex-m/compare/v0.6.5...v0.6.6
 [v0.6.5]: https://github.com/rust-embedded/cortex-m/compare/v0.6.4...v0.6.5
 [v0.6.4]: https://github.com/rust-embedded/cortex-m/compare/v0.6.3...v0.6.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2018"
 
 [dependencies]

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -84,6 +84,9 @@ pub mod mpu;
 pub mod nvic;
 pub mod scb;
 
+#[cfg(all(not(armv6m), not(armv8m_base)))]
+pub use cortex_m_0_7::peripheral::itm;
+
 pub use cortex_m_0_7::peripheral::{cpuid, dcb, dwt, syst};
 #[cfg(not(armv6m))]
 pub use cortex_m_0_7::peripheral::{fpb, tpiu};


### PR DESCRIPTION
This fixes the issue where cortex-m 0.5.10 re-exports 0.6's peripheral::itm module; in principle it's possible other crates could have been using this module directly too (it is public) but in practice it doesn't contain anything useful (all the useful things are in the top-level itm module).

Should fix https://github.com/rust-embedded/discovery/issues/287.