### PR TITLE
Prepare 0.5.11, removing linking to pre-built binaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.11] - 2021-01-31
+
+* This release stops linking the pre-built assembly files, as those methods are
+  instead provided by depending on cortex-m 0.6.x.
+
+## [v0.5.10] - 2019-04-29
+
+* This release ensures features set on this cortex-m crate are forwarded to
+  the included cortex-m 0.6.x crate.
+
+## [v0.5.9] - 2019-04-28
+
+* This release re-exports compatible types from cortex-m 0.6.x, allowing use
+  of both versions in one project.
+
 ## [v0.5.8] - 2018-10-27
 
 ### Added
@@ -529,7 +544,10 @@ fn main() {
 - Functions to get the vector table
 - Wrappers over miscellaneous instructions like `bkpt`
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.5.8...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.5.11...HEAD
+[v0.5.11]: https://github.com/rust-embedded/cortex-m/compare/v0.5.10...v0.5.11
+[v0.5.10]: https://github.com/rust-embedded/cortex-m/compare/v0.5.9...v0.5.10
+[v0.5.9]: https://github.com/rust-embedded/cortex-m/compare/v0.5.8...v0.5.9
 [v0.5.8]: https://github.com/rust-embedded/cortex-m/compare/v0.5.7...v0.5.8
 [v0.5.7]: https://github.com/rust-embedded/cortex-m/compare/v0.5.6...v0.5.7
 [v0.5.6]: https://github.com/rust-embedded/cortex-m/compare/v0.5.5...v0.5.6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.5.10"
+version = "0.5.11"
 
 [dependencies]
 aligned = "0.2.0"

--- a/build.rs
+++ b/build.rs
@@ -6,16 +6,6 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let name = env::var("CARGO_PKG_NAME").unwrap();
 
-    if target.starts_with("thumb") && env::var_os("CARGO_FEATURE_INLINE_ASM").is_none() {
-        fs::copy(
-            format!("bin/{}.a", target),
-            out_dir.join(format!("lib{}.a", name)),
-        ).unwrap();
-
-        println!("cargo:rustc-link-lib=static={}", name);
-        println!("cargo:rustc-link-search={}", out_dir.display());
-    }
-
     if target.starts_with("thumbv6m-") {
         println!("cargo:rustc-cfg=cortex_m");
         println!("cargo:rustc-cfg=armv6m");


### PR DESCRIPTION
_I don't really like this. These semver hacks are getting out of hand and are mega cursed._

In https://github.com/rust-embedded/discovery/issues/288 it's reported that crates which use cortex-m 0.5 (such as our discovery book) have started to fail to build in some cases because of duplicate symbols such as `__cpsid` exported from the pre-built binaries.

It turns out in 0.5.10 we continue to link against a pre-built binary, but don't use it as the `asm` module is instead exported from `cortex_m_0_6` (i.e. 0.6.7, which itself exports it from 0.7.1).

What I don't understand is why this issue didn't appear before now, since it seems like 0.6.4 and below should have also exported these symbols and so should have also collided. I'd love some light on what's going on there.

This potential PR would release a 0.5.11 which just stops linking the pre-built binaries (and adds 0.5.9/10 to the changelog). I've tested that this change fixes the Discovery build, so it's one way we could fix this. Open to other, less cursed, suggestions too.