### PR TITLE
Fix rust-lld: error: undefined symbol: __syscall

### DIFF
--- a/cortex-m-semihosting/src/lib.rs
+++ b/cortex-m-semihosting/src/lib.rs
@@ -194,7 +194,7 @@ pub mod nr;
 
 #[cfg(all(thumb, not(feature = "inline-asm")))]
 extern "C" {
-    fn __syscall(nr: usize, arg: usize) -> usize;
+    fn __sh_syscall(nr: usize, arg: usize) -> usize;
 }
 
 /// Performs a semihosting operation, takes a pointer to an argument block
@@ -208,7 +208,7 @@ pub unsafe fn syscall<T>(nr: usize, arg: &T) -> usize {
 pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
     match () {
         #[cfg(all(thumb, not(feature = "inline-asm"), not(feature = "no-semihosting")))]
-        () => __syscall(_nr, _arg),
+        () => __sh_syscall(_nr, _arg),
 
         #[cfg(all(thumb, feature = "inline-asm", not(feature = "no-semihosting")))]
         () => {


### PR DESCRIPTION
Encountered while building an example from stm32-rs/stm32f3xx-hal