### PR TITLE
Relax check-blobs check

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -159,7 +159,8 @@ pub fn check_blobs() {
     let mut files_before = BTreeMap::new();
     for entry in fs::read_dir("bin").unwrap() {
         let entry = entry.unwrap();
-        if entry.path().extension().unwrap() == "a" {
+        // Only check -lto.a files since those have the same symbol order between Linux and macOS
+        if entry.path().to_str().unwrap().ends_with("-lto.a") {
             files_before.insert(
                 entry
                     .path()
@@ -178,7 +179,8 @@ pub fn check_blobs() {
     let mut files_after = BTreeMap::new();
     for entry in fs::read_dir("bin").unwrap() {
         let entry = entry.unwrap();
-        if entry.path().extension().unwrap() == "a" {
+        // Only check -lto.a files since those have the same symbol order between Linux and macOS
+        if entry.path().to_str().unwrap().ends_with("-lto.a") {
             files_after.insert(
                 entry
                     .path()


### PR DESCRIPTION
Turns out rustc has an unstable symbol order between Linux and macOS,
but only if `-Clinker-plugin-lto` is not used, so let's only check those
archives for binary changes for now.

Closes #329

Signed-off-by: Daniel Egger <daniel@eggers-club.de>