### PR TITLE
Remove an extra function call in `primask::read`

### DIFF
--- a/src/register/primask.rs
+++ b/src/register/primask.rs
@@ -26,11 +26,7 @@ impl Primask {
 /// Reads the CPU register
 #[inline]
 pub fn read() -> Primask {
-    fn read_raw() -> u32 {
-        call_asm!(__primask_r() -> u32)
-    }
-
-    let r = read_raw();
+    let r: u32 = call_asm!(__primask_r() -> u32);
     if r & (1 << 0) == (1 << 0) {
         Primask::Inactive
     } else {


### PR DESCRIPTION
There doesn't seem to be any reason why the call to `__primask_r` should be wrapped by another function call. `read_raw` (the function being removed by this PR) is not `#[inline]`, so it did hurt performance when compiled without LTO.

Compare with `faultmask::read`:
https://github.com/rust-embedded/cortex-m/blob/7481f09d67aee7081d71cf6e042f2984c12a830f/src/register/faultmask.rs#L26-L35