### PR TITLE
Implement various interfaces for trace configuration

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -3,7 +3,7 @@ delete_merged_branches = true
 required_approvals = 1
 status = [
   "ci-linux (stable)",
-  "ci-linux (1.38.0)",
+  "ci-linux (1.40.0)",
   "rustfmt",
   "clippy",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.38.0
+          - rust: 1.40.0
 
           # Test nightly but don't fail
           - rust: nightly

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is developed and maintained by the [Cortex-M team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.38 and up. It might compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.40 and up. It might compile with older versions but that may change in any new patch release.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.38 and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.40 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 
 #![cfg_attr(feature = "inline-asm", feature(asm))]

--- a/src/peripheral/dcb.rs
+++ b/src/peripheral/dcb.rs
@@ -25,6 +25,10 @@ impl DCB {
     /// `peripheral::DWT` cycle counter to work properly.
     /// As by STM documentation, this flag is not reset on
     /// soft-reset, only on power reset.
+    ///
+    /// Note: vendor-specific registers may have to be set to completely
+    /// enable tracing. For example, on the STM32F401RE, `TRACE_MODE`
+    /// and `TRACE_IOEN` must be configured in `DBGMCU_CR` register.
     #[inline]
     pub fn enable_trace(&mut self) {
         // set bit 24 / TRCENA

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -56,14 +56,14 @@ bitfield! {
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct Ctrl(u32);
-    get_cyccntena, set_cyccntena: 0;
-    get_pcsamplena, set_pcsamplena: 12;
-    get_exctrcena, set_exctrcena: 16;
-    get_noprfcnt, _: 24;
-    get_nocyccnt, _: 25;
-    get_noexttrig, _: 26;
-    get_notrcpkt, _: 27;
-    u8, get_numcomp, _: 31, 28;
+    cyccntena, set_cyccntena: 0;
+    pcsamplena, set_pcsamplena: 12;
+    exctrcena, set_exctrcena: 16;
+    noprfcnt, _: 24;
+    nocyccnt, _: 25;
+    noexttrig, _: 26;
+    notrcpkt, _: 27;
+    u8, numcomp, _: 31, 28;
 }
 
 /// Comparator
@@ -83,11 +83,11 @@ bitfield! {
     #[derive(Copy, Clone)]
     /// Comparator FUNCTIONn register.
     pub struct Function(u32);
-    u8, get_function, set_function: 3, 0;
-    get_emitrange, set_emitrange: 5;
-    get_cycmatch, set_cycmatch: 7;
-    get_datavmatch, set_datavmatch: 8;
-    get_matched, _: 24;
+    u8, function, set_function: 3, 0;
+    emitrange, set_emitrange: 5;
+    cycmatch, set_cycmatch: 7;
+    datavmatch, set_datavmatch: 8;
+    matched, _: 24;
 }
 
 impl DWT {
@@ -96,35 +96,35 @@ impl DWT {
     /// A value of zero indicates no comparator support.
     #[inline]
     pub fn num_comp(&self) -> u8 {
-        self.ctrl.read().get_numcomp()
+        self.ctrl.read().numcomp()
     }
 
     /// Returns `true` if the the implementation supports sampling and exception tracing
     #[cfg(not(armv6m))]
     #[inline]
     pub fn has_exception_trace(&self) -> bool {
-        self.ctrl.read().get_notrcpkt() == false
+        self.ctrl.read().notrcpkt() == false
     }
 
     /// Returns `true` if the implementation includes external match signals
     #[cfg(not(armv6m))]
     #[inline]
     pub fn has_external_match(&self) -> bool {
-        self.ctrl.read().get_noexttrig() == false
+        self.ctrl.read().noexttrig() == false
     }
 
     /// Returns `true` if the implementation supports a cycle counter
     #[cfg(not(armv6m))]
     #[inline]
     pub fn has_cycle_counter(&self) -> bool {
-        self.ctrl.read().get_nocyccnt() == false
+        self.ctrl.read().nocyccnt() == false
     }
 
     /// Returns `true` if the implementation the profiling counters
     #[cfg(not(armv6m))]
     #[inline]
     pub fn has_profiling_counter(&self) -> bool {
-        self.ctrl.read().get_noprfcnt() == false
+        self.ctrl.read().noprfcnt() == false
     }
 
     /// Enables the cycle counter
@@ -150,7 +150,7 @@ impl DWT {
     #[cfg(not(armv6m))]
     #[inline]
     pub fn cycle_counter_enabled(&self) -> bool {
-        self.ctrl.read().get_cyccntena()
+        self.ctrl.read().cyccntena()
     }
 
     /// Whether to enable exception tracing

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -78,7 +78,7 @@ bitfield! {
     #[derive(Copy, Clone)]
     /// Comparator FUNCTIONn register.
     pub struct Function(u32);
-    get_function, set_function: 3, 0;
+    u8, get_function, set_function: 3, 0;
     get_emitrange, set_emitrange: 5;
     get_cycmatch, set_cycmatch: 7;
     get_datavmatch, set_datavmatch: 8;

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -99,7 +99,7 @@ impl DWT {
     }
 
     /// Whether to enable exception tracing
-    // TODO find out if this is supported om armv6m
+    #[cfg(not(armv6m))]
     #[inline]
     pub fn enable_exception_tracing(&mut self, bit: bool) {
         unsafe {
@@ -111,7 +111,7 @@ impl DWT {
     }
 
     /// Whether to periodically generate PC samples
-    // TODO find out if this is supported on armv6m
+    #[cfg(not(armv6m))]
     #[inline]
     pub fn enable_pc_samples(&mut self, bit: bool) {
         unsafe {
@@ -210,8 +210,8 @@ impl Comparator {
                     // don't compare data value
                     r.set_datavmatch(false);
 
-                    // dont compare cycle counter value
-                    // NOTE: only needed forp comparator 0, but is SBZP.
+                    // don't compare cycle counter value
+                    // NOTE: only needed for comparator 0, but is SBZP.
                     r.set_cycmatch(false);
 
                     // FUNCTION, EMITRANGE

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -353,7 +353,7 @@ pub enum ComparatorFunction {
 
 /// Possible error values returned on [Comparator::configure].
 #[derive(Debug)]
-pub enum DWTError {
+pub enum DwtError {
     /// Invalid combination of [AccessType] and [EmitOption].
     InvalidFunction,
 }
@@ -383,7 +383,7 @@ impl Comparator {
                     (AccessType::ReadWrite, EmitOption::PCData) => (0b0011, false),
 
                     (AccessType::ReadWrite, EmitOption::PC) => (0b0001, false),
-                    (_, EmitOption::PC) => return Err(DWTError::InvalidFunction),
+                    (_, EmitOption::PC) => return Err(DwtError::InvalidFunction),
                 };
 
                 self.function.modify(|mut r| {

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -173,6 +173,7 @@ pub enum DWTError {
 
 impl Comparator {
     /// Configure the function of the comparator
+    #[inline]
     pub fn configure(&mut self, settings: ComparatorFunction) -> Result<(), DWTError> {
         match settings {
             ComparatorFunction::Address(settings) => unsafe {

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -322,7 +322,8 @@ pub enum EmitOption {
     /// Emit only trace address packet.
     Address,
     /// Emit only trace PC value packet
-    /// NOTE: only compatible with [AccessType::ReadWrite].
+    ///
+    /// *NOTE* only compatible with [AccessType::ReadWrite].
     PC,
     /// Emit trace address and data value packets.
     AddressData,

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -70,6 +70,34 @@ impl DWT {
         unsafe { self.ctrl.modify(|r| r | 1) }
     }
 
+    /// Whether to enable exception tracing
+    // TODO find out if this is supported om armv6m
+    #[inline]
+    pub fn enable_exception_tracing(&mut self, bit: bool) {
+        unsafe {
+            // EXCTRCENA
+            if bit {
+                self.ctrl.modify(|r| r | (1 << 16));
+            } else {
+                self.ctrl.modify(|r| r & !(1 << 16));
+            }
+        }
+    }
+
+    /// Whether to periodically generate PC samples
+    // TODO find out if this is supported on armv6m
+    #[inline]
+    pub fn enable_pc_samples(&mut self, bit: bool) {
+        unsafe {
+            // PCSAMPLENA
+            if bit {
+                self.ctrl.modify(|r| r | (1 << 12));
+            } else {
+                self.ctrl.modify(|r| r & !(1 << 12));
+            }
+        }
+    }
+
     /// Returns the current clock cycle count
     #[cfg(not(armv6m))]
     #[inline]

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -103,28 +103,28 @@ impl DWT {
     #[cfg(not(armv6m))]
     #[inline]
     pub fn has_exception_trace(&self) -> bool {
-        self.ctrl.read().notrcpkt() == false
+        !self.ctrl.read().notrcpkt()
     }
 
     /// Returns `true` if the implementation includes external match signals
     #[cfg(not(armv6m))]
     #[inline]
     pub fn has_external_match(&self) -> bool {
-        self.ctrl.read().noexttrig() == false
+        !self.ctrl.read().noexttrig()
     }
 
     /// Returns `true` if the implementation supports a cycle counter
     #[cfg(not(armv6m))]
     #[inline]
     pub fn has_cycle_counter(&self) -> bool {
-        self.ctrl.read().nocyccnt() == false
+        !self.ctrl.read().nocyccnt()
     }
 
     /// Returns `true` if the implementation the profiling counters
     #[cfg(not(armv6m))]
     #[inline]
     pub fn has_profiling_counter(&self) -> bool {
-        self.ctrl.read().noprfcnt() == false
+        !self.ctrl.read().noprfcnt()
     }
 
     /// Enables the cycle counter

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -360,8 +360,8 @@ pub enum DWTError {
 
 impl Comparator {
     /// Configure the function of the comparator
-    #[inline]
-    pub fn configure(&self, settings: ComparatorFunction) -> Result<(), DWTError> {
+    #[allow(clippy::missing_inline_in_public_items)]
+    pub fn configure(&self, settings: ComparatorFunction) -> Result<(), DwtError> {
         match settings {
             ComparatorFunction::Address(settings) => unsafe {
                 if settings.emit == EmitOption::PC && settings.access_type != AccessType::ReadWrite

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -304,7 +304,7 @@ impl DWT {
 }
 
 /// Whether the comparator should match on read, write or read/write operations.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum AccessType {
     /// Generate packet only when matched adress is read from.
     ReadOnly,
@@ -315,7 +315,7 @@ pub enum AccessType {
 }
 
 /// The sequence of packet(s) that should be emitted on comparator match.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum EmitOption {
     /// Emit only trace data value packet.
     Data,
@@ -332,7 +332,7 @@ pub enum EmitOption {
 }
 
 /// Settings for address matching
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct ComparatorAddressSettings {
     /// The address to match against.
     pub address: u32,
@@ -345,7 +345,7 @@ pub struct ComparatorAddressSettings {
 }
 
 /// The available functions of a DWT comparator.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[non_exhaustive]
 pub enum ComparatorFunction {
     /// Compare accessed memory addresses.
@@ -353,7 +353,7 @@ pub enum ComparatorFunction {
 }
 
 /// Possible error values returned on [Comparator::configure].
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[non_exhaustive]
 pub enum DwtError {
     /// Invalid combination of [AccessType] and [EmitOption].

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -153,13 +153,25 @@ impl DWT {
         self.ctrl.read().cyccntena()
     }
 
-    /// Whether to enable exception tracing
+    /// Enables exception tracing
     #[cfg(not(armv6m))]
     #[inline]
-    pub fn enable_exception_tracing(&mut self, bit: bool) {
+    pub fn enable_exception_tracing(&mut self) {
         unsafe {
             self.ctrl.modify(|mut r| {
-                r.set_exctrcena(bit);
+                r.set_exctrcena(true);
+                r
+            });
+        }
+    }
+
+    /// Disables exception tracing
+    #[cfg(not(armv6m))]
+    #[inline]
+    pub fn disable_exception_tracing(&mut self) {
+        unsafe {
+            self.ctrl.modify(|mut r| {
+                r.set_exctrcena(false);
                 r
             });
         }

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -346,6 +346,7 @@ pub struct ComparatorAddressSettings {
 
 /// The available functions of a DWT comparator.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ComparatorFunction {
     /// Compare accessed memory addresses.
     Address(ComparatorAddressSettings),
@@ -353,6 +354,7 @@ pub enum ComparatorFunction {
 
 /// Possible error values returned on [Comparator::configure].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DwtError {
     /// Invalid combination of [AccessType] and [EmitOption].
     InvalidFunction,

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -90,7 +90,7 @@ impl Stim {
 }
 
 /// The possible local timestamp options.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum LocalTimestampOptions {
     /// Disable local timestamps.
     Disabled,
@@ -108,7 +108,7 @@ pub enum LocalTimestampOptions {
 }
 
 /// The possible global timestamp options.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum GlobalTimestampOptions {
     /// Disable global timestamps.
     Disabled,
@@ -121,7 +121,7 @@ pub enum GlobalTimestampOptions {
 }
 
 /// The possible clock sources for timestamp counters.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum TimestampClkSrc {
     /// Clock timestamp counters using the system processor clock.
     SystemClock,
@@ -134,7 +134,7 @@ pub enum TimestampClkSrc {
 }
 
 /// Available settings for the ITM peripheral.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct ITMSettings {
     /// Whether to enable ITM.
     pub enable: bool,

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -7,6 +7,9 @@ use core::ptr;
 
 use volatile_register::{RO, RW, WO};
 
+use crate::peripheral::ITM;
+use bitfield::bitfield;
+
 /// Register block
 #[repr(C)]
 pub struct RegisterBlock {
@@ -20,12 +23,28 @@ pub struct RegisterBlock {
     pub tpr: RW<u32>,
     reserved2: [u32; 15],
     /// Trace Control
-    pub tcr: RW<u32>,
+    pub tcr: RW<Tcr>,
     reserved3: [u32; 75],
     /// Lock Access
     pub lar: WO<u32>,
     /// Lock Status
     pub lsr: RO<u32>,
+}
+
+bitfield! {
+    /// Trace Control Register.
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct Tcr(u32);
+    get_itmena, set_itmena: 0;
+    get_tsena, set_tsena: 1;
+    get_syncena, set_synena: 2;
+    get_txena, set_txena: 3;
+    get_swoena, set_swoena: 4;
+    get_tsprescale, set_tsprecale: 9, 8;
+    get_gtsfreq, set_gtsfreq: 11, 10;
+    get_tracebusid, set_tracebusid: 22, 16;
+    busy, _: 23;
 }
 
 /// Stimulus Port
@@ -67,5 +86,108 @@ impl Stim {
         // proceed with a stimulus write if the port is either ready (bit 0) or
         // disabled (bit 1).
         unsafe { ptr::read_volatile(self.register.get()) & 0b11 != 0 }
+    }
+}
+
+/// The possible local timestamp options.
+#[derive(Debug, PartialEq)]
+pub enum LocalTimestampOptions {
+    /// Disable local timestamps.
+    Disabled,
+    /// Enable local timestamps and use no prescaling.
+    Enabled,
+    /// Enable local timestamps and set the prescaler to divide the
+    /// reference clock by 4.
+    EnabledDiv4,
+    /// Enable local timestamps and set the prescaler to divide the
+    /// reference clock by 16.
+    EnabledDiv16,
+    /// Enable local timestamps and set the prescaler to divide the
+    /// reference clock by 64.
+    EnabledDiv64,
+}
+
+/// The possible global timestamp options.
+#[derive(Debug)]
+pub enum GlobalTimestampOptions {
+    /// Disable global timestamps.
+    Disabled,
+    /// Generate a global timestamp approximately every 128 cycles.
+    Every128Cycles,
+    /// Generate a global timestamp approximately every 8921 cycles.
+    Every8192Cycles,
+    /// Generate a global timestamp after every packet, if the output FIFO is empty.
+    EveryPacket,
+}
+
+/// The possible clock sources for timestamp counters.
+#[derive(Debug)]
+pub enum TimestampClkSrc {
+    /// Clock timestamp counters using the system processor clock.
+    SystemClock,
+    /// Clock timestamp counters using the asynchronous clock from the
+    /// TPIU interface.
+    ///
+    /// NOTE: The timestamp counter is held in reset while the output
+    /// line is idle.
+    AsyncTPIU,
+}
+
+/// blah
+#[derive(Debug)]
+pub struct ITMSettings {
+    /// Whether to enable ITM.
+    pub enable: bool,
+    /// Whether DWT packets should be forwarded to ITM.
+    pub forward_dwt: bool,
+    /// The local timestamp options that should be applied.
+    pub local_timestamps: LocalTimestampOptions,
+    /// The global timestamp options that should be applied.
+    pub global_timestamps: GlobalTimestampOptions,
+    /// The trace bus ID to use when multi-trace sources are in use.
+    /// `None` specifies that only a single trace source is in use and
+    /// has the same effect as `Some(0)`.
+    pub bus_id: Option<u8>,
+    /// The clock that should increase timestamp counters.
+    pub timestamp_clk_src: TimestampClkSrc,
+}
+
+impl ITM {
+    /// Removes the software lock on the ITM.
+    #[inline]
+    pub fn unlock(&mut self) {
+        // NOTE(unsafe) atomic write to a stateless, write-only register
+        unsafe { self.lar.write(0xC5AC_CE55) }
+    }
+
+    /// Configures the ITM with the passed [ITMSettings].
+    #[inline]
+    pub fn configure(&mut self, settings: ITMSettings) {
+        unsafe {
+            self.tcr.modify(|mut r| {
+                r.set_itmena(settings.enable);
+                r.set_tsena(settings.local_timestamps != LocalTimestampOptions::Disabled);
+                r.set_txena(settings.forward_dwt);
+                r.set_tsprecale(match settings.local_timestamps {
+                    LocalTimestampOptions::Disabled | LocalTimestampOptions::Enabled => 0b00,
+                    LocalTimestampOptions::EnabledDiv4 => 0b10,
+                    LocalTimestampOptions::EnabledDiv16 => 0b10,
+                    LocalTimestampOptions::EnabledDiv64 => 0b11,
+                });
+                r.set_gtsfreq(match settings.global_timestamps {
+                    GlobalTimestampOptions::Disabled => 0b00,
+                    GlobalTimestampOptions::Every128Cycles => 0b01,
+                    GlobalTimestampOptions::Every8192Cycles => 0b10,
+                    GlobalTimestampOptions::EveryPacket => 0b11,
+                });
+                r.set_swoena(match settings.timestamp_clk_src {
+                    TimestampClkSrc::SystemClock => false,
+                    TimestampClkSrc::AsyncTPIU => true,
+                });
+                r.set_tracebusid(settings.bus_id.unwrap_or(0).into());
+
+                r
+            });
+        }
     }
 }

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -41,9 +41,9 @@ bitfield! {
     get_syncena, set_synena: 2;
     get_txena, set_txena: 3;
     get_swoena, set_swoena: 4;
-    get_tsprescale, set_tsprecale: 9, 8;
-    get_gtsfreq, set_gtsfreq: 11, 10;
-    get_tracebusid, set_tracebusid: 22, 16;
+    u8, get_tsprescale, set_tsprecale: 9, 8;
+    u8, get_gtsfreq, set_gtsfreq: 11, 10;
+    u8, get_tracebusid, set_tracebusid: 22, 16;
     busy, _: 23;
 }
 

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -133,7 +133,7 @@ pub enum TimestampClkSrc {
     AsyncTPIU,
 }
 
-/// blah
+/// Available settings for the ITM peripheral.
 #[derive(Debug)]
 pub struct ITMSettings {
     /// Whether to enable ITM.

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -184,7 +184,7 @@ impl ITM {
                     TimestampClkSrc::SystemClock => false,
                     TimestampClkSrc::AsyncTPIU => true,
                 });
-                r.set_tracebusid(settings.bus_id.unwrap_or(0).into());
+                r.set_tracebusid(settings.bus_id.unwrap_or(0));
 
                 r
             });

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -41,7 +41,7 @@ bitfield! {
     get_syncena, set_synena: 2;
     get_txena, set_txena: 3;
     get_swoena, set_swoena: 4;
-    u8, get_tsprescale, set_tsprecale: 9, 8;
+    u8, get_tsprescale, set_tsprescale: 9, 8;
     u8, get_gtsfreq, set_gtsfreq: 11, 10;
     u8, get_tracebusid, set_tracebusid: 22, 16;
     busy, _: 23;
@@ -168,7 +168,7 @@ impl ITM {
                 r.set_itmena(settings.enable);
                 r.set_tsena(settings.local_timestamps != LocalTimestampOptions::Disabled);
                 r.set_txena(settings.forward_dwt);
-                r.set_tsprecale(match settings.local_timestamps {
+                r.set_tsprescale(match settings.local_timestamps {
                     LocalTimestampOptions::Disabled | LocalTimestampOptions::Enabled => 0b00,
                     LocalTimestampOptions::EnabledDiv4 => 0b10,
                     LocalTimestampOptions::EnabledDiv16 => 0b10,

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -36,14 +36,14 @@ bitfield! {
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct Tcr(u32);
-    get_itmena, set_itmena: 0;
-    get_tsena, set_tsena: 1;
-    get_syncena, set_synena: 2;
-    get_txena, set_txena: 3;
-    get_swoena, set_swoena: 4;
-    u8, get_tsprescale, set_tsprescale: 9, 8;
-    u8, get_gtsfreq, set_gtsfreq: 11, 10;
-    u8, get_tracebusid, set_tracebusid: 22, 16;
+    itmena, set_itmena: 0;
+    tsena, set_tsena: 1;
+    syncena, set_synena: 2;
+    txena, set_txena: 3;
+    swoena, set_swoena: 4;
+    u8, tsprescale, set_tsprescale: 9, 8;
+    u8, gtsfreq, set_gtsfreq: 11, 10;
+    u8, tracebusid, set_tracebusid: 22, 16;
     busy, _: 23;
 }
 

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -220,6 +220,7 @@ impl Peripherals {
 }
 
 /// Cache and branch predictor maintenance operations
+#[allow(clippy::upper_case_acronyms)]
 pub struct CBP {
     _marker: PhantomData<*const ()>,
 }
@@ -256,6 +257,7 @@ impl ops::Deref for CBP {
 }
 
 /// CPUID
+#[allow(clippy::upper_case_acronyms)]
 pub struct CPUID {
     _marker: PhantomData<*const ()>,
 }
@@ -283,6 +285,7 @@ impl ops::Deref for CPUID {
 }
 
 /// Debug Control Block
+#[allow(clippy::upper_case_acronyms)]
 pub struct DCB {
     _marker: PhantomData<*const ()>,
 }
@@ -310,6 +313,7 @@ impl ops::Deref for DCB {
 }
 
 /// Data Watchpoint and Trace unit
+#[allow(clippy::upper_case_acronyms)]
 pub struct DWT {
     _marker: PhantomData<*const ()>,
 }
@@ -337,6 +341,7 @@ impl ops::Deref for DWT {
 }
 
 /// Flash Patch and Breakpoint unit
+#[allow(clippy::upper_case_acronyms)]
 pub struct FPB {
     _marker: PhantomData<*const ()>,
 }
@@ -366,6 +371,7 @@ impl ops::Deref for FPB {
 }
 
 /// Floating Point Unit
+#[allow(clippy::upper_case_acronyms)]
 pub struct FPU {
     _marker: PhantomData<*const ()>,
 }
@@ -400,6 +406,7 @@ impl ops::Deref for FPU {
 /// `actlr`. It's called the "implementation control block" in the ARMv8-M
 /// standard, but earlier standards contained the registers, just without a
 /// name.
+#[allow(clippy::upper_case_acronyms)]
 pub struct ICB {
     _marker: PhantomData<*const ()>,
 }
@@ -434,6 +441,7 @@ impl ops::DerefMut for ICB {
 }
 
 /// Instrumentation Trace Macrocell
+#[allow(clippy::upper_case_acronyms)]
 pub struct ITM {
     _marker: PhantomData<*const ()>,
 }
@@ -471,6 +479,7 @@ impl ops::DerefMut for ITM {
 }
 
 /// Memory Protection Unit
+#[allow(clippy::upper_case_acronyms)]
 pub struct MPU {
     _marker: PhantomData<*const ()>,
 }
@@ -498,6 +507,7 @@ impl ops::Deref for MPU {
 }
 
 /// Nested Vector Interrupt Controller
+#[allow(clippy::upper_case_acronyms)]
 pub struct NVIC {
     _marker: PhantomData<*const ()>,
 }
@@ -525,6 +535,7 @@ impl ops::Deref for NVIC {
 }
 
 /// Security Attribution Unit
+#[allow(clippy::upper_case_acronyms)]
 pub struct SAU {
     _marker: PhantomData<*const ()>,
 }
@@ -554,6 +565,7 @@ impl ops::Deref for SAU {
 }
 
 /// System Control Block
+#[allow(clippy::upper_case_acronyms)]
 pub struct SCB {
     _marker: PhantomData<*const ()>,
 }
@@ -581,6 +593,7 @@ impl ops::Deref for SCB {
 }
 
 /// SysTick: System Timer
+#[allow(clippy::upper_case_acronyms)]
 pub struct SYST {
     _marker: PhantomData<*const ()>,
 }
@@ -608,6 +621,7 @@ impl ops::Deref for SYST {
 }
 
 /// Trace Port Interface Unit
+#[allow(clippy::upper_case_acronyms)]
 pub struct TPIU {
     _marker: PhantomData<*const ()>,
 }

--- a/src/peripheral/tpiu.rs
+++ b/src/peripheral/tpiu.rs
@@ -108,7 +108,7 @@ impl TPIU {
     /// Reads the supported trace output modes and the minimum size of
     /// the TPIU FIFO queue for trace data.
     #[inline]
-    pub fn get_swo_supports() -> SWOSupports {
+    pub fn swo_supports() -> SWOSupports {
         let _type = unsafe { (*Self::ptr())._type.read() };
         SWOSupports {
             nrz_encoding: _type.nrzvalid(),

--- a/src/peripheral/tpiu.rs
+++ b/src/peripheral/tpiu.rs
@@ -38,7 +38,7 @@ bitfield! {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct Ffcr(u32);
-    get_enfcont, set_enfcont: 1;
+    enfcont, set_enfcont: 1;
 }
 
 bitfield! {

--- a/src/peripheral/tpiu.rs
+++ b/src/peripheral/tpiu.rs
@@ -62,6 +62,7 @@ bitfield! {
 
 /// The available protocols for the trace output.
 #[repr(u8)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum TraceProtocol {
     /// Parallel trace port mode
     Parallel = 0b00,
@@ -87,7 +88,7 @@ impl core::convert::TryFrom<u8> for TraceProtocol {
 }
 
 /// The SWO options supported by the TPIU.
-#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct SWOSupports {
     /// Whether UART/NRZ encoding is supported for SWO.
     nrz_encoding: bool,

--- a/src/peripheral/tpiu.rs
+++ b/src/peripheral/tpiu.rs
@@ -42,7 +42,7 @@ bitfield! {
 }
 
 bitfield! {
-    /// Type Register.
+    /// TPIU Type Register.
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct Type(u32);

--- a/src/peripheral/tpiu.rs
+++ b/src/peripheral/tpiu.rs
@@ -92,9 +92,9 @@ impl TPIU {
     pub fn get_swo_supports() -> SWOSupports {
         let _type = unsafe { (*Self::ptr())._type.read() };
         SWOSupports {
-            nrz_encoding: (_type & (1 << 11)) == 1,        // NRZVALID
-            manchester_encoding: (_type & (1 << 10)) == 1, // MANCVALID
-            parallel_operation: (_type & (1 << 9)) == 1,   // PTINVALID
+            nrz_encoding: (_type & (1 << 11)) != 0,        // NRZVALID
+            manchester_encoding: (_type & (1 << 10)) != 0, // MANCVALID
+            parallel_operation: (_type & (1 << 9)) != 0,   // PTINVALID
             min_queue_size: (_type & (0b111 << 6)) as u8,  // FIFOSZ
         }
     }


### PR DESCRIPTION
I'm working on tracing support and aim to implement functions that abstract the configuration of relevant peripherals. Of chief interest is `DWT`, `ITM` and `TPIU`. Some propored abstractions will go against what is established in the crate; I will ask for comments on these.