### PR TITLE
Remove dependence on embedded-hal for Delay

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -29,7 +29,8 @@ impl Delay {
         self.syst
     }
 
-    fn _delay_us(&mut self, us: u32) {
+    /// Delay using the Cortex-M systick for a certain duration, µs.
+    pub fn delay_us(&mut self, us: u32) {
         let ticks = (us as u64) * (self.ahb_frequency as u64) / 1_000_000;
 
         let full_cycles = ticks >> 24;
@@ -54,6 +55,11 @@ impl Delay {
 
         self.syst.disable_counter();
     }
+
+    /// Delay using the Cortex-M systick for a certain duration, ms.
+    pub fn delay_ms(&mut self, ms: u32) {
+        self.delay_us(ms * 1_000);
+    }
 }
 
 impl DelayMs<u32> for Delay {
@@ -61,10 +67,10 @@ impl DelayMs<u32> for Delay {
     fn delay_ms(&mut self, mut ms: u32) {
         // 4294967 is the highest u32 value which you can multiply by 1000 without overflow
         while ms > 4294967 {
-            self.delay_us(4294967000u32);
+            Delay::delay_us(self, 4294967000u32);
             ms -= 4294967;
         }
-        self.delay_us(ms * 1_000);
+        Delay::delay_us(self, ms * 1_000);
     }
 }
 
@@ -73,28 +79,28 @@ impl DelayMs<i32> for Delay {
     #[inline(always)]
     fn delay_ms(&mut self, ms: i32) {
         assert!(ms >= 0);
-        self.delay_ms(ms as u32);
+        Delay::delay_ms(self, ms as u32);
     }
 }
 
 impl DelayMs<u16> for Delay {
     #[inline(always)]
     fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(u32::from(ms));
+        Delay::delay_ms(self, u32::from(ms));
     }
 }
 
 impl DelayMs<u8> for Delay {
     #[inline(always)]
     fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(u32::from(ms));
+        Delay::delay_ms(self, u32::from(ms));
     }
 }
 
 impl DelayUs<u32> for Delay {
     #[inline]
     fn delay_us(&mut self, us: u32) {
-        self._delay_us(us);
+        Delay::delay_us(self, us);
     }
 }
 
@@ -103,20 +109,20 @@ impl DelayUs<i32> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: i32) {
         assert!(us >= 0);
-        self.delay_us(us as u32);
+        Delay::delay_us(self, us as u32);
     }
 }
 
 impl DelayUs<u16> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u16) {
-        self.delay_us(u32::from(us))
+        Delay::delay_us(self, u32::from(us))
     }
 }
 
 impl DelayUs<u8> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u8) {
-        self.delay_us(u32::from(us))
+        Delay::delay_us(self, u32::from(us))
     }
 }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -31,7 +31,7 @@ impl Delay {
 
     /// Delay using the Cortex-M systick for a certain duration, in µs.
     pub fn delay_us(&mut self, us: u32) {
-        let ticks = (us as u64) * (self.ahb_frequency as u64) / 1_000_000;
+        let ticks = (u64::from(us)) * (u64::from(self.ahb_frequency)) / 1_000_000;
 
         let full_cycles = ticks >> 24;
         if full_cycles > 0 {
@@ -87,14 +87,14 @@ impl DelayMs<i32> for Delay {
 impl DelayMs<u16> for Delay {
     #[inline(always)]
     fn delay_ms(&mut self, ms: u16) {
-        Delay::delay_ms(self, ms as u32);
+        Delay::delay_ms(self, u32::from(ms));
     }
 }
 
 impl DelayMs<u8> for Delay {
     #[inline(always)]
     fn delay_ms(&mut self, ms: u8) {
-        Delay::delay_ms(self, ms as u32);
+        Delay::delay_ms(self, u32::from(ms));
     }
 }
 
@@ -117,13 +117,13 @@ impl DelayUs<i32> for Delay {
 impl DelayUs<u16> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u16) {
-        Delay::delay_us(self, us as u32)
+        Delay::delay_us(self, u32::from(us))
     }
 }
 
 impl DelayUs<u8> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u8) {
-        Delay::delay_us(self, us as u32)
+        Delay::delay_us(self, u32::from(us))
     }
 }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -30,6 +30,7 @@ impl Delay {
     }
 
     /// Delay using the Cortex-M systick for a certain duration, in µs.
+    #[allow(clippy::missing_inline_in_public_items)]
     pub fn delay_us(&mut self, us: u32) {
         let ticks = (u64::from(us)) * (u64::from(self.ahb_frequency)) / 1_000_000;
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -30,6 +30,7 @@ impl Delay {
     }
 
     /// Delay using the Cortex-M systick for a certain duration, µs.
+    #[inline]
     pub fn delay_us(&mut self, us: u32) {
         let ticks = (us as u64) * (self.ahb_frequency as u64) / 1_000_000;
 
@@ -57,20 +58,21 @@ impl Delay {
     }
 
     /// Delay using the Cortex-M systick for a certain duration, ms.
-    pub fn delay_ms(&mut self, ms: u32) {
-        self.delay_us(ms * 1_000);
-    }
-}
-
-impl DelayMs<u32> for Delay {
     #[inline]
-    fn delay_ms(&mut self, mut ms: u32) {
+    pub fn delay_ms(&mut self, mut ms: u32) {
         // 4294967 is the highest u32 value which you can multiply by 1000 without overflow
         while ms > 4294967 {
             Delay::delay_us(self, 4294967000u32);
             ms -= 4294967;
         }
         Delay::delay_us(self, ms * 1_000);
+    }
+}
+
+impl DelayMs<u32> for Delay {
+    #[inline]
+    fn delay_ms(&mut self, ms: u32) {
+        Delay::delay_ms(self, ms);
     }
 }
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -29,7 +29,7 @@ impl Delay {
         self.syst
     }
 
-    /// Delay using the Cortex-M systick for a certain duration, µs.
+    /// Delay using the Cortex-M systick for a certain duration, in µs.
     #[inline]
     pub fn delay_us(&mut self, us: u32) {
         let ticks = (us as u64) * (self.ahb_frequency as u64) / 1_000_000;
@@ -57,15 +57,15 @@ impl Delay {
         self.syst.disable_counter();
     }
 
-    /// Delay using the Cortex-M systick for a certain duration, ms.
+    /// Delay using the Cortex-M systick for a certain duration, in ms.
     #[inline]
     pub fn delay_ms(&mut self, mut ms: u32) {
         // 4294967 is the highest u32 value which you can multiply by 1000 without overflow
         while ms > 4294967 {
-            Delay::delay_us(self, 4294967000u32);
+            self.delay_us(4294967000u32);
             ms -= 4294967;
         }
-        Delay::delay_us(self, ms * 1_000);
+        self.delay_us(ms * 1_000);
     }
 }
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -30,7 +30,6 @@ impl Delay {
     }
 
     /// Delay using the Cortex-M systick for a certain duration, in µs.
-    #[inline]
     pub fn delay_us(&mut self, us: u32) {
         let ticks = (us as u64) * (self.ahb_frequency as u64) / 1_000_000;
 
@@ -88,14 +87,14 @@ impl DelayMs<i32> for Delay {
 impl DelayMs<u16> for Delay {
     #[inline(always)]
     fn delay_ms(&mut self, ms: u16) {
-        Delay::delay_ms(self, u32::from(ms));
+        Delay::delay_ms(self, ms as u32);
     }
 }
 
 impl DelayMs<u8> for Delay {
     #[inline(always)]
     fn delay_ms(&mut self, ms: u8) {
-        Delay::delay_ms(self, u32::from(ms));
+        Delay::delay_ms(self, ms as u32);
     }
 }
 
@@ -118,13 +117,13 @@ impl DelayUs<i32> for Delay {
 impl DelayUs<u16> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u16) {
-        Delay::delay_us(self, u32::from(us))
+        Delay::delay_us(self, us as u32)
     }
 }
 
 impl DelayUs<u8> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u8) {
-        Delay::delay_us(self, u32::from(us))
+        Delay::delay_us(self, us as u32)
     }
 }


### PR DESCRIPTION
Fixes #343

No functional changes. Allows you to use Delay as previously, or without including or importing `embedded-hal`.