### PR TITLE
Add pre-requisites for enabling the cycle counter to docs

### DIFF
--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -64,6 +64,13 @@ pub struct Comparator {
 
 impl DWT {
     /// Enables the cycle counter
+    ///
+    /// The global trace enable ([`DCB::enable_trace`]) should be set before
+    /// enabling the cycle counter, the processor may ignore writes to the
+    /// cycle counter enable if the global trace is disabled
+    /// (implementation defined behaviour).
+    ///
+    /// [`DCB::enable_trace`]: crate::peripheral::DCB::enable_trace
     #[cfg(not(armv6m))]
     #[inline]
     pub fn enable_cycle_counter(&mut self) {


### PR DESCRIPTION
I think adding a note here about per-requisites for the cycle counter is a good idea.

Reference: https://developer.arm.com/documentation/ddi0403/d/Debug-Architecture/ARMv7-M-Debug/Debug-register-support-in-the-SCS/Debug-Exception-and-Monitor-Control-Register--DEMCR?lang=en#BCGJGAGC

This may just be a me issue, I always forget to set the global trace enable when I go to use the cycle counter.  Feel free to close if you think this is a non-issue.