### PR TITLE
Add DWT.set_cycle_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - Exception overhead counter
     - LSU counter
     - Folded-instruction counter
+- Added `DWT.set_cycle_count` (#347).
 
 ### Deprecated
 

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -160,6 +160,13 @@ impl DWT {
         unsafe { (*Self::ptr()).cyccnt.read() }
     }
 
+    /// Set the cycle count
+    #[cfg(not(armv6m))]
+    #[inline]
+    pub fn set_cycle_count(&mut self, count: u32) {
+        unsafe { self.cyccnt.write(count) }
+    }
+
     /// Removes the software lock on the DWT
     ///
     /// Some devices, like the STM32F7, software lock the DWT after a power cycle.


### PR DESCRIPTION
This method is helpful to reset the cycle count when using it as a timestamp.