### PR TITLE
Replace URL-relative doc links with intra-doc links

### DIFF
--- a/src/peripheral/nvic.rs
+++ b/src/peripheral/nvic.rs
@@ -210,7 +210,7 @@ impl NVIC {
     /// # Unsafety
     ///
     /// Changing priority levels can break priority-based critical sections (see
-    /// [`register::basepri`](../register/basepri/index.html)) and compromise memory safety.
+    /// [`register::basepri`](crate::register::basepri)) and compromise memory safety.
     #[inline]
     pub unsafe fn set_priority<I>(&mut self, interrupt: I, prio: u8)
     where

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -994,7 +994,7 @@ impl SCB {
     /// # Unsafety
     ///
     /// Changing priority levels can break priority-based critical sections (see
-    /// [`register::basepri`](../register/basepri/index.html)) and compromise memory safety.
+    /// [`register::basepri`](crate::register::basepri)) and compromise memory safety.
     #[inline]
     pub unsafe fn set_priority(&mut self, system_handler: SystemHandler, prio: u8) {
         let index = system_handler as u8;


### PR DESCRIPTION
This fixes invalid documentation links for crates that re-export `cortex-m`.