### PR TITLE
Add the Cortex-M7 TCM and cache access control registers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - LSU counter
     - Folded-instruction counter
 - Added `DWT.set_cycle_count` (#347).
+- Added support for the Cortex-M7 TCM and cache access control registers.
+  There is a feature `cm7` to enable access to these.
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ bitfield = "0.13.2"
 embedded-hal = "0.2.4"
 
 [features]
-cm7-r0p1 = []
+cm7 = []
+cm7-r0p1 = ["cm7"]
 inline-asm = []
 linker-plugin-lto = []
 

--- a/src/peripheral/ac.rs
+++ b/src/peripheral/ac.rs
@@ -1,0 +1,93 @@
+//! Cortex-M7 TCM and Cache access control.
+
+use volatile_register::RW;
+
+/// Register block
+#[repr(C)]
+pub struct RegisterBlock {
+    /// Instruction Tightly-Coupled Memory Control Register
+    pub itcmcr: RW<u32>,
+    /// Data Tightly-Coupled Memory Control Register
+    pub dtcmcr: RW<u32>,
+    /// AHBP Control Register
+    pub ahbpcr: RW<u32>,
+    /// L1 Cache Control Register
+    pub cacr: RW<u32>,
+    /// AHB Slave Control Register
+    pub ahbscr: RW<u32>,
+    reserved0: u32,
+    /// Auxilary Bus Fault Status Register
+    pub abfsr: RW<u32>,
+}
+
+/// ITCMCR and DTCMCR TCM enable bit.
+pub const TCM_EN: u32 = 1;
+
+/// ITCMCR and DTCMCR TCM read-modify-write bit.
+pub const TCM_RMW: u32 = 2;
+
+/// ITCMCR and DTCMCR TCM rety phase enable bit.
+pub const TCM_RETEN: u32 = 4;
+
+/// ITCMCR and DTCMCR TCM size mask.
+pub const TCM_SZ_MASK: u32 = 0x78;
+
+/// ITCMCR and DTCMCR TCM shift.
+pub const TCM_SZ_SHIFT: usize = 3;
+
+/// AHBPCR AHBP enable bit.
+pub const AHBPCR_EN: u32 = 1;
+
+/// AHBPCR AHBP size mask.
+pub const AHBPCR_SZ_MASK: u32 = 0x0e;
+
+/// AHBPCR AHBP size shit.
+pub const AHBPCR_SZ_SHIFT: usize = 1;
+
+/// CACR Shared cachedable-is-WT for data cache.
+pub const CACR_SIWT: u32 = 1;
+
+/// CACR ECC in the instruction and data cache (disable).
+pub const CACR_ECCDIS: u32 = 2;
+
+/// CACR Force Write-Through in the data cache.
+pub const CACR_FORCEWT: u32 = 4;
+
+/// AHBSCR AHBS prioritization control mask.
+pub const AHBSCR_CTL_MASK: u32 = 0x03;
+
+/// AHBSCR AHBS prioritization control shift.
+pub const AHBSCR_CTL_SHIFT: usize = 0;
+
+/// AHBSCR Threshold execution prioity for AHBS traffic demotion, mask.
+pub const AHBSCR_TPRI_MASK: u32 = 0x7fc;
+
+/// AHBSCR Threshold execution prioity for AHBS traffic demotion, shift.
+pub const AHBSCR_TPRI_SHIFT: usize = 2;
+
+/// AHBSCR Failness counter initialization value, mask.
+pub const AHBSCR_INITCOUNT_MASK: u32 = 0xf800;
+
+/// AHBSCR Failness counter initialization value, shift.
+pub const AHBSCR_INITCOUNT_SHIFT: usize = 11;
+
+/// ABFSR Async fault on ITCM interface.
+pub const ABFSR_ITCM: u32 = 1;
+
+/// ABFSR Async fault on DTCM interface.
+pub const ABFSR_DTCM: u32 = 2;
+
+/// ABFSR Async fault on AHBP interface.
+pub const ABFSR_AHBP: u32 = 4;
+
+/// ABFSR Async fault on AXIM interface.
+pub const ABFSR_AXIM: u32 = 8;
+
+/// ABFSR Async fault on EPPB interface.
+pub const ABFSR_EPPB: u32 = 16;
+
+/// ABFSR Indicates the type of fault on the AXIM interface, mask.
+pub const ABFSR_AXIMTYPE_MASK: u32 = 0x300;
+
+/// ABFSR Indicates the type of fault on the AXIM interface, shift.
+pub const ABFSR_AXIMTYPE_SHIFT: usize = 8;

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -60,6 +60,8 @@ use core::ops;
 
 use crate::interrupt;
 
+#[cfg(cm7)]
+pub mod ac;
 #[cfg(not(armv6m))]
 pub mod cbp;
 pub mod cpuid;
@@ -91,6 +93,10 @@ mod test;
 #[allow(non_snake_case)]
 #[allow(clippy::manual_non_exhaustive)]
 pub struct Peripherals {
+    /// Cortex-M7 TCM and cache access control.
+    #[cfg(cm7)]
+    pub AC: AC,
+
     /// Cache and branch predictor maintenance operations.
     /// Not available on Armv6-M.
     pub CBP: CBP,
@@ -172,6 +178,10 @@ impl Peripherals {
         TAKEN = true;
 
         Peripherals {
+            #[cfg(cm7)]
+            AC: AC {
+                _marker: PhantomData,
+            },
             CBP: CBP {
                 _marker: PhantomData,
             },
@@ -216,6 +226,27 @@ impl Peripherals {
             },
             _priv: (),
         }
+    }
+}
+
+/// Access control
+#[cfg(cm7)]
+pub struct AC {
+    _marker: PhantomData<*const ()>,
+}
+
+#[cfg(cm7)]
+unsafe impl Send for AC {}
+
+#[cfg(cm7)]
+impl AC {
+    /// Pointer to the register block
+    pub const PTR: *const self::ac::RegisterBlock = 0xE000_EF90 as *const _;
+
+    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    #[inline(always)]
+    pub const fn ptr() -> *const self::ac::RegisterBlock {
+        Self::PTR
     }
 }
 


### PR DESCRIPTION
Add the Cortex-M7 TCM and cache access control registers.

These are documented in the Cortex-M7 generic user guide (ARM DUI 0646C). 

I'm not sure what feature gate these should be on - should I add a new one for Cortex-M7? Currently I have them on `not(armv6m)` - they do not appear to be in the ARMv7M architecture documentation, so I presume they are M7 specific.