### PR TITLE
Fix minimal dependency build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
 
 [dependencies]
-bare-metal = { version = "0.2.0", features = ["const-fn"] }
+bare-metal = { version = "0.2.4", features = ["const-fn"] }
 volatile-register = "0.2.0"
 bitfield = "0.13.2"
 embedded-hal = "0.2.4"


### PR DESCRIPTION
With 

```bash
cargo +nightly update -Z minimal-versions
cargo build
```

Following error occurred:

<details><summary>
bare-metal v0.2.1: const_fn feature has been removed
</summary>

```
$ cargo +nightly update -Z minimal-versions
    Updating crates.io index
    Updating bare-metal v0.2.5 -> v0.2.1
    Updating embedded-hal v0.2.6 -> v0.2.4
    Removing nb v0.1.3
    Removing nb v1.0.0
      Adding nb v0.1.1
    Removing rustc_version v0.2.3
    Removing semver v0.9.0
    Removing semver-parser v0.7.0
    Updating vcell v0.1.3 -> v0.1.0
    Updating volatile-register v0.2.1 -> v0.2.0
$ cargo build
  Downloaded vcell v0.1.0
  Downloaded nb v0.1.1
  Downloaded 2 crates (15.4 KB) in 1.02s
   Compiling vcell v0.1.0
   Compiling void v1.0.2
   Compiling nb v0.1.1
   Compiling bare-metal v0.2.1
error[E0557]: feature has been removed
 --> /home/fabian/.cargo/registry/src/github.com-1ecc6299db9ec823/bare-metal-0.2.1/src/lib.rs:7:13
  |
7 |     feature(const_fn, const_unsafe_cell_new)
  |             ^^^^^^^^ feature has been removed
  |
  = note: split into finer-grained feature gates

error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/fabian/.cargo/registry/src/github.com-1ecc6299db9ec823/bare-metal-0.2.1/src/lib.rs:7:5
  |
7 |     feature(const_fn, const_unsafe_cell_new)
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Some errors have detailed explanations: E0554, E0557.
For more information about an error, try `rustc --explain E0554`.
error: could not compile `bare-metal` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed

```
</details>

Setting the minimal version of `bare-metal` to `v0.2.4` fixes the issue. 