### PR TITLE
scb: derive serde, Hash, PartialOrd for VectActive behind gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,17 @@ volatile-register = "0.2.0"
 bitfield = "0.13.2"
 embedded-hal = "0.2.4"
 
+[dependencies.serde]
+version = "1"
+features = [ "derive" ]
+optional = true
+
 [features]
 cm7 = []
 cm7-r0p1 = ["cm7"]
 inline-asm = []
 linker-plugin-lto = []
+std-map = []
 
 [workspace]
 members = ["xtask", "cortex-m-semihosting", "panic-semihosting", "panic-itm"]

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -11,6 +11,8 @@ use super::CBP;
 #[cfg(not(armv6m))]
 use super::CPUID;
 use super::SCB;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Register block
 #[repr(C)]
@@ -194,6 +196,8 @@ impl SCB {
 
 /// Processor core exceptions (internal interrupts)
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std-map", derive(PartialOrd, Hash))]
 pub enum Exception {
     /// Non maskable interrupt
     NonMaskableInt,
@@ -259,6 +263,8 @@ impl Exception {
 
 /// Active exception number
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std-map", derive(PartialOrd, Hash))]
 pub enum VectActive {
     /// Thread mode
     ThreadMode,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,3 +11,5 @@ harness = false
 
 [dependencies]
 ar = "0.8.0"
+cortex-m = { path = "../", features = ["serde", "std-map"] }
+serde_json = "1"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -208,3 +208,24 @@ pub fn check_blobs() {
 
     println!("Blobs identical.");
 }
+
+// Check that serde and PartialOrd works with VectActive
+pub fn check_host_side() {
+    use cortex_m::peripheral::scb::VectActive;
+
+    // check serde
+    {
+        let v = VectActive::from(22).unwrap();
+        let json = serde_json::to_string(&v).expect("Failed to serialize VectActive");
+        let deser_v: VectActive =
+            serde_json::from_str(&json).expect("Failed to deserialize VectActive");
+        assert_eq!(deser_v, v);
+    }
+
+    // check PartialOrd
+    {
+        let a = VectActive::from(19).unwrap();
+        let b = VectActive::from(20).unwrap();
+        assert_eq!(a < b, true);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,17 +1,19 @@
 use std::{env, process};
-use xtask::{assemble_blobs, check_blobs};
+use xtask::{assemble_blobs, check_blobs, check_host_side};
 
 fn main() {
     let subcommand = env::args().skip(1).next();
     match subcommand.as_ref().map(|s| &**s) {
         Some("assemble") => assemble_blobs(),
         Some("check-blobs") => check_blobs(),
+        Some("check-host-side") => check_host_side(),
         _ => {
             eprintln!("usage: cargo xtask <subcommand>");
             eprintln!();
             eprintln!("subcommands:");
-            eprintln!("    assemble     Reassemble the pre-built artifacts");
-            eprintln!("    check-blobs  Check that the pre-built artifacts are up-to-date and reproducible");
+            eprintln!("    assemble         Reassemble the pre-built artifacts");
+            eprintln!("    check-blobs      Check that the pre-built artifacts are up-to-date and reproducible");
+            eprintln!("    check-host-side  Build the crate in a non-Cortex-M host application and check host side usage of certain types");
             process::exit(1);
         }
     }

--- a/xtask/tests/ci.rs
+++ b/xtask/tests/ci.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 use std::{env, str};
-use xtask::{check_blobs, install_targets};
+use xtask::{check_blobs, check_host_side, install_targets};
 
 /// List of all compilation targets we support.
 ///
@@ -105,4 +105,7 @@ fn main() {
     let is_nightly = str::from_utf8(&output.stdout).unwrap().contains("nightly");
 
     check_crates_build(is_nightly);
+
+    // Check host-side applications of the crate.
+    check_host_side();
 }


### PR DESCRIPTION
Exposes two new feature gates for VectActive serde::{Serialize,
Deserialize} (via "serde") and Hash, PartialOrd (via "std-map") for use
on host-side ITM tracing programs. While the struct itself is not
received directly over ITM, its use greatly simplifies the
implementation by allowing VectActive as keys in map collections and
file/socket {,de}serialization to forward the structure elsewhere. These
features are not enabled by default.

Before this patch, serde functionality could be realized via [0], but
this does not propagate down a dependency chain (i.e. if realized for
crate B, which crate A depends on, serde functionality is not exposed in
crate A unless VectActive is wrapped in a type from crate B). I am not
aware of any method to realize PartialOrd, Hash derivation for a
downstream crate.

[0] https://serde.rs/remote-derive.html