### PR TITLE
itm: derive serde for `LocalTimestampOptions`, impl gated `TryFrom<u8>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cm7 = []
 cm7-r0p1 = ["cm7"]
 inline-asm = []
 linker-plugin-lto = []
-std-map = []
+std = []
 
 [workspace]
 members = ["xtask", "cortex-m-semihosting", "panic-semihosting", "panic-itm"]

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -111,7 +111,7 @@ pub enum LocalTimestampOptions {
     EnabledDiv64,
 }
 
-#[cfg(feature = "std-map")]
+#[cfg(feature = "std")]
 impl core::convert::TryFrom<u8> for LocalTimestampOptions {
     type Error = ();
 

--- a/src/peripheral/itm.rs
+++ b/src/peripheral/itm.rs
@@ -10,6 +10,9 @@ use volatile_register::{RO, RW, WO};
 use crate::peripheral::ITM;
 use bitfield::bitfield;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Register block
 #[repr(C)]
 pub struct RegisterBlock {
@@ -91,6 +94,7 @@ impl Stim {
 
 /// The possible local timestamp options.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LocalTimestampOptions {
     /// Disable local timestamps.
     Disabled,
@@ -105,6 +109,24 @@ pub enum LocalTimestampOptions {
     /// Enable local timestamps and set the prescaler to divide the
     /// reference clock by 64.
     EnabledDiv64,
+}
+
+#[cfg(feature = "std-map")]
+impl core::convert::TryFrom<u8> for LocalTimestampOptions {
+    type Error = ();
+
+    /// Converts an integer value to an enabled [LocalTimestampOptions]
+    /// variant. Accepted values are: 1, 4, 16, 64. Any other value
+    /// yields `Err(())`.
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Enabled),
+            4 => Ok(Self::EnabledDiv4),
+            16 => Ok(Self::EnabledDiv16),
+            64 => Ok(Self::EnabledDiv64),
+            _ => Err(()),
+        }
+    }
 }
 
 /// The possible global timestamp options.

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -197,7 +197,7 @@ impl SCB {
 /// Processor core exceptions (internal interrupts)
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std-map", derive(PartialOrd, Hash))]
+#[cfg_attr(feature = "std", derive(PartialOrd, Hash))]
 pub enum Exception {
     /// Non maskable interrupt
     NonMaskableInt,
@@ -264,7 +264,7 @@ impl Exception {
 /// Active exception number
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std-map", derive(PartialOrd, Hash))]
+#[cfg_attr(feature = "std", derive(PartialOrd, Hash))]
 pub enum VectActive {
     /// Thread mode
     ThreadMode,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,5 +11,5 @@ harness = false
 
 [dependencies]
 ar = "0.8.0"
-cortex-m = { path = "../", features = ["serde", "std-map"] }
+cortex-m = { path = "../", features = ["serde", "std"] }
 serde_json = "1"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -211,7 +211,7 @@ pub fn check_blobs() {
 
 // Check that serde and PartialOrd works with VectActive
 pub fn check_host_side() {
-    use cortex_m::peripheral::scb::VectActive;
+    use cortex_m::peripheral::{itm::LocalTimestampOptions, scb::VectActive};
 
     // check serde
     {
@@ -220,6 +220,12 @@ pub fn check_host_side() {
         let deser_v: VectActive =
             serde_json::from_str(&json).expect("Failed to deserialize VectActive");
         assert_eq!(deser_v, v);
+
+        let lts = LocalTimestampOptions::EnabledDiv4;
+        let json = serde_json::to_string(&lts).expect("Failed to serialize LocalTimestampOptions");
+        let deser_lts: LocalTimestampOptions =
+            serde_json::from_str(&json).expect("Failed to deserilaize LocalTimestampOptions");
+        assert_eq!(deser_lts, lts);
     }
 
     // check PartialOrd
@@ -227,5 +233,16 @@ pub fn check_host_side() {
         let a = VectActive::from(19).unwrap();
         let b = VectActive::from(20).unwrap();
         assert_eq!(a < b, true);
+    }
+
+    // check TryFrom
+    {
+        use core::convert::TryInto;
+        use std::convert::TryFrom;
+
+        let lts: LocalTimestampOptions = (16 as u8).try_into().unwrap();
+        assert_eq!(lts, LocalTimestampOptions::EnabledDiv16);
+
+        assert!(LocalTimestampOptions::try_from(42).is_err());
     }
 }


### PR DESCRIPTION
This PR is an upstream push of more std-features required by `cargo-rtic-scope`. If required, the `TryFrom<u8>` impl can be kept downstream.