### PR TITLE
add methods needed for cycle count comparisons

### DIFF
--- a/src/peripheral/dcb.rs
+++ b/src/peripheral/dcb.rs
@@ -6,6 +6,7 @@ use crate::peripheral::DCB;
 use core::ptr;
 
 const DCB_DEMCR_TRCENA: u32 = 1 << 24;
+const DCB_DEMCR_MON_EN: u32 = 1 << 16;
 
 /// Register block
 #[repr(C)]
@@ -43,6 +44,20 @@ impl DCB {
         // unset bit 24 / TRCENA
         unsafe {
             self.demcr.modify(|w| w & !DCB_DEMCR_TRCENA);
+        }
+    }
+
+    /// Enables the [`DebugMonitor`](crate::peripheral::scb::Exception::DebugMonitor) exception
+    pub fn enable_debug_monitor(&mut self) {
+        unsafe {
+            self.demcr.modify(|w| w | DCB_DEMCR_MON_EN);
+        }
+    }
+
+    /// Disables the [`DebugMonitor`](crate::peripheral::scb::Exception::DebugMonitor) exception
+    pub fn disable_debug_monitor(&mut self) {
+        unsafe {
+            self.demcr.modify(|w| w & !DCB_DEMCR_MON_EN);
         }
     }
 

--- a/src/peripheral/dcb.rs
+++ b/src/peripheral/dcb.rs
@@ -48,6 +48,7 @@ impl DCB {
     }
 
     /// Enables the [`DebugMonitor`](crate::peripheral::scb::Exception::DebugMonitor) exception
+    #[inline]
     pub fn enable_debug_monitor(&mut self) {
         unsafe {
             self.demcr.modify(|w| w | DCB_DEMCR_MON_EN);
@@ -55,6 +56,7 @@ impl DCB {
     }
 
     /// Disables the [`DebugMonitor`](crate::peripheral::scb::Exception::DebugMonitor) exception
+    #[inline]
     pub fn disable_debug_monitor(&mut self) {
         unsafe {
             self.demcr.modify(|w| w & !DCB_DEMCR_MON_EN);

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -392,7 +392,7 @@ pub enum ComparatorFunction {
     /// Compare cycle count & target value.
     ///
     /// **NOTE**: only supported by comparator 0 and if the HW supports the cycle counter.
-    /// Check `dwt.has_cycle_counter` for support. See C1.8.1 for more details.
+    /// Check [`DWT::has_cycle_counter`] for support. See C1.8.1 for more details.
     CycleCount(CycleCountSettings),
 }
 

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -389,9 +389,10 @@ pub struct CycleCountSettings {
 pub enum ComparatorFunction {
     /// Compare accessed memory addresses.
     Address(ComparatorAddressSettings),
-    /// Compare cycle count  & target value.
+    /// Compare cycle count & target value.
     ///
-    /// **NOTE**: only supported by comparator 0. See C1.8.1.
+    /// **NOTE**: only supported by comparator 0 and if the HW supports the cycle counter.
+    /// Check `dwt.has_cycle_counter` for support. See C1.8.1 for more details.
     CycleCount(CycleCountSettings),
 }
 
@@ -408,7 +409,7 @@ pub enum DwtError {
 impl Comparator {
     /// Configure the function of the comparator
     #[allow(clippy::missing_inline_in_public_items)]
-    pub fn configure(&self, dwt: &DWT, settings: ComparatorFunction) -> Result<(), DwtError> {
+    pub fn configure(&self, settings: ComparatorFunction) -> Result<(), DwtError> {
         match settings {
             ComparatorFunction::Address(settings) => {
                 // FUNCTION, EMITRANGE
@@ -461,10 +462,6 @@ impl Comparator {
                 }
             }
             ComparatorFunction::CycleCount(settings) => {
-                if !dwt.has_cycle_counter() {
-                    return Err(DwtError::NoCycleCount);
-                }
-
                 let function = match &settings.emit {
                     EmitOption::PCData => 0b0001,
                     EmitOption::WatchpointDebugEvent => 0b0100,

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -120,10 +120,13 @@ impl DWT {
     }
 
     /// Returns `true` if the implementation supports a cycle counter
-    #[cfg(not(armv6m))]
     #[inline]
     pub fn has_cycle_counter(&self) -> bool {
-        !self.ctrl.read().nocyccnt()
+        #[cfg(not(armv6m))]
+        return !self.ctrl.read().nocyccnt();
+
+        #[cfg(armv6m)]
+        return false;
     }
 
     /// Returns `true` if the implementation the profiling counters

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -341,14 +341,13 @@ pub enum EmitOption {
     AddressData,
     /// Emit trace PC value and data value packets.
     PCData,
-    /// Generate a watchpoint debug event.
+    /// Generate a watchpoint debug event. Either halts execution or fires a `DebugMonitor` exception.
     ///
-    /// either halts execution or fires a `DebugMonitor` exception.
-    /// See more in section "Watchpoint debug event generation" page C1-729
+    /// See more in section "Watchpoint debug event generation" page C1-729.
     WatchpointDebugEvent,
     /// Generate a `CMPMATCH[N]` event.
     ///
-    /// See more in section "CMPMATCH[N] event generation" page C1-730
+    /// See more in section "CMPMATCH[N] event generation" page C1-730.
     CompareMatchEvent,
 }
 
@@ -369,7 +368,7 @@ pub struct ComparatorAddressSettings {
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct CycleCountSettings {
     /// The function selection used.
-    /// See Table C1-15 DWT cycle count comparison functions
+    /// See Table C1-15 for DWT cycle count comparison functions.
     pub emit: EmitOption,
     /// The cycle count value to compare against.
     pub compare: u32,

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -402,8 +402,6 @@ pub enum ComparatorFunction {
 pub enum DwtError {
     /// Invalid combination of [AccessType] and [EmitOption].
     InvalidFunction,
-    /// The DWT block does not implement cycle count capabilities.
-    NoCycleCount,
 }
 
 impl Comparator {

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -428,7 +428,7 @@ impl Comparator {
                     // emit a Debug Watchpoint event, either halting execution or
                     // firing a `DebugMonitor` exception
                     0b0111,
-                    // don't emit (we're going to fire an exception not trace)
+                    // emit_range is N/A for cycle count compare
                     false,
                     // don't compare data
                     false,

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -90,9 +90,9 @@ bitfield! {
     cycmatch, set_cycmatch: 7;
     datavmatch, set_datavmatch: 8;
     lnk1ena, set_lnk1ena: 9;
-    u8, datavsize, set_datavsize: 2, 10;
-    u8, datavaddr0, set_datavaddr0: 4, 12;
-    u8, datavaddr1, set_datavaddr1: 4, 16;
+    u8, datavsize, set_datavsize: 11, 10;
+    u8, datavaddr0, set_datavaddr0: 15, 12;
+    u8, datavaddr1, set_datavaddr1: 19, 16;
     matched, _: 24;
 }
 
@@ -448,6 +448,10 @@ impl Comparator {
                         // don't compare cycle counter value
                         // NOTE: only needed for comparator 0, but is SBZP.
                         r.set_cycmatch(false);
+                        // SBZ as needed, see Page 784/C1-724
+                        r.set_datavsize(0);
+                        r.set_datavaddr0(0);
+                        r.set_datavaddr1(0);
 
                         r
                     });


### PR DESCRIPTION
Extends the existing DWT comparator code to include cycle count comparisons which fire a `DebugMonitor` exception, if enabled with `enable_debug_monitor`. See working example [here](https://github.com/TDHolmes/embedded-profiling/blob/58d8b106921977816e2b5a05bcb43e976197edaf/ep-dwt/src/lib.rs#L57)