### PR TITLE
Switch "native" check from being x86_64 only to checking `HOST`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,11 @@ use std::{env, fs};
 
 fn main() {
     let target = env::var("TARGET").unwrap();
+    let host_triple = env::var("HOST").unwrap();
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let name = env::var("CARGO_PKG_NAME").unwrap();
+
+    let native_compilation = host_triple == target;
 
     if target.starts_with("thumb") {
         let suffix = if env::var_os("CARGO_FEATURE_LINKER_PLUGIN_LTO").is_some() {
@@ -43,7 +46,7 @@ fn main() {
         println!("cargo:rustc-cfg=armv8m_main");
     }
 
-    if target.ends_with("-eabihf") {
-        println!("cargo:rustc-cfg=has_fpu");
+    if native_compilation {
+        println!("cargo:rustc-cfg=native");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,9 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let name = env::var("CARGO_PKG_NAME").unwrap();
 
-    let native_compilation = host_triple == target;
+    if host_triple == target {
+        println!("cargo:rustc-cfg=native");
+    }
 
     if target.starts_with("thumb") {
         let suffix = if env::var_os("CARGO_FEATURE_LINKER_PLUGIN_LTO").is_some() {
@@ -46,7 +48,7 @@ fn main() {
         println!("cargo:rustc-cfg=armv8m_main");
     }
 
-    if native_compilation {
-        println!("cargo:rustc-cfg=native");
+    if target.ends_with("-eabihf") {
+        println!("cargo:rustc-cfg=has_fpu");
     }
 }

--- a/src/peripheral/icb.rs
+++ b/src/peripheral/icb.rs
@@ -1,6 +1,6 @@
 //! Implementation Control Block
 
-#[cfg(any(armv7m, armv8m, target_arch = "x86_64"))]
+#[cfg(any(armv7m, armv8m, native))]
 use volatile_register::RO;
 use volatile_register::RW;
 
@@ -12,12 +12,12 @@ pub struct RegisterBlock {
     /// The bottom four bits of this register give the number of implemented
     /// interrupt lines, divided by 32. So a value of `0b0010` indicates 64
     /// interrupts.
-    #[cfg(any(armv7m, armv8m, target_arch = "x86_64"))]
+    #[cfg(any(armv7m, armv8m, native))]
     pub ictr: RO<u32>,
 
     /// The ICTR is not defined in the ARMv6-M Architecture Reference manual, so
     /// we replace it with this.
-    #[cfg(not(any(armv7m, armv8m, target_arch = "x86_64")))]
+    #[cfg(not(any(armv7m, armv8m, native)))]
     _reserved: u32,
 
     /// Auxiliary Control Register

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -71,8 +71,8 @@ pub mod dcb;
 pub mod dwt;
 #[cfg(not(armv6m))]
 pub mod fpb;
-// NOTE(target_arch) is for documentation purposes
-#[cfg(any(has_fpu, target_arch = "x86_64"))]
+// NOTE(native) is for documentation purposes
+#[cfg(any(has_fpu, native))]
 pub mod fpu;
 pub mod icb;
 #[cfg(all(not(armv6m), not(armv8m_base)))]
@@ -411,7 +411,7 @@ pub struct FPU {
 
 unsafe impl Send for FPU {}
 
-#[cfg(any(has_fpu, target_arch = "x86_64"))]
+#[cfg(any(has_fpu, native))]
 impl FPU {
     /// Pointer to the register block
     pub const PTR: *const fpu::RegisterBlock = 0xE000_EF30 as *const _;
@@ -423,7 +423,7 @@ impl FPU {
     }
 }
 
-#[cfg(any(has_fpu, target_arch = "x86_64"))]
+#[cfg(any(has_fpu, native))]
 impl ops::Deref for FPU {
     type Target = self::fpu::RegisterBlock;
 

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -182,7 +182,7 @@ impl SCB {
             5 => VectActive::Exception(Exception::BusFault),
             #[cfg(not(armv6m))]
             6 => VectActive::Exception(Exception::UsageFault),
-            #[cfg(any(armv8m, target_arch = "x86_64"))]
+            #[cfg(any(armv8m, native))]
             7 => VectActive::Exception(Exception::SecureFault),
             11 => VectActive::Exception(Exception::SVCall),
             #[cfg(not(armv6m))]
@@ -218,7 +218,7 @@ pub enum Exception {
     UsageFault,
 
     /// Secure fault interrupt (only on ARMv8-M)
-    #[cfg(any(armv8m, target_arch = "x86_64"))]
+    #[cfg(any(armv8m, native))]
     SecureFault,
 
     /// SV call interrupt
@@ -250,7 +250,7 @@ impl Exception {
             Exception::BusFault => -11,
             #[cfg(not(armv6m))]
             Exception::UsageFault => -10,
-            #[cfg(any(armv8m, target_arch = "x86_64"))]
+            #[cfg(any(armv8m, native))]
             Exception::SecureFault => -9,
             Exception::SVCall => -5,
             #[cfg(not(armv6m))]
@@ -293,7 +293,7 @@ impl VectActive {
             5 => VectActive::Exception(Exception::BusFault),
             #[cfg(not(armv6m))]
             6 => VectActive::Exception(Exception::UsageFault),
-            #[cfg(any(armv8m, target_arch = "x86_64"))]
+            #[cfg(any(armv8m, native))]
             7 => VectActive::Exception(Exception::SecureFault),
             11 => VectActive::Exception(Exception::SVCall),
             #[cfg(not(armv6m))]
@@ -934,7 +934,7 @@ pub enum SystemHandler {
     UsageFault = 6,
 
     /// Secure fault interrupt (only on ARMv8-M)
-    #[cfg(any(armv8m, target_arch = "x86_64"))]
+    #[cfg(any(armv8m, native))]
     SecureFault = 7,
 
     /// SV call interrupt


### PR DESCRIPTION
If `HOST==TARGET`, we know we're compiling natively. Set a new `rustc` cfg for this and use it where we previously checked for `x86_64`.

I was trying to run tests on my M1 MacBook Pro and couldn't since it isn't `x86_64`. Also, the currently configured nightly compiler for asm doesn't have M1 support, so I updated that. I'm fine reverting that change though, I can just do that locally, but I'm sure others will hit the same issue and it's a bit old...