### PR TITLE
`SCB.ICSR.VECTACTIVE` is 9 bits, not 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   There is a feature `cm7` to enable access to these.
 - Added `delay::Delay::with_source`, a constructor that lets you specify
   the SysTick clock source (#374).
+- Added the capability for `DWT` to do cycle count comparison (#367).
+- Updated `SCB.ICSR.VECTACTIVE`/`SCB::vect_active()` to be 9 bits instead of 8.
+  Also fixes `VectActive::from` to take a `u16` and subtract `16` for
+  `VectActive::Interrupt`s to match `SBC::vect_active()` (#373).
 
 ### Deprecated
 

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -301,7 +301,7 @@ impl VectActive {
             12 => VectActive::Exception(Exception::DebugMonitor),
             14 => VectActive::Exception(Exception::PendSV),
             15 => VectActive::Exception(Exception::SysTick),
-            irqn if irqn >= 16 && irqn < 512 => VectActive::Interrupt { irqn: irqn - 16 },
+            irqn if (16..512).contains(&irqn) => VectActive::Interrupt { irqn: irqn - 16 },
             _ => return None,
         })
     }


### PR DESCRIPTION
Closes #332