### PR TITLE
Construct a SysTick delay with a clock source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `DWT.set_cycle_count` (#347).
 - Added support for the Cortex-M7 TCM and cache access control registers.
   There is a feature `cm7` to enable access to these.
+- Added `delay::Delay::with_source`, a constructor that lets you specify
+  the SysTick clock source (#374).
 
 ### Deprecated
 


### PR DESCRIPTION
Helpful for users who prefer an external clock source for their system
timer. Proposing this as a 0.7 backwards-compatible change.