### PR TITLE
TPIU: swo_supports: make struct fields public, improve documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DWT: add `configure` API for address, cycle count comparison (#342, #367).
 - ITM: add `configure` API (#342).
 - TPIU: add API for *Formatter and Flush Control* (FFCR) and *Selected Pin Control* (SPPR) registers (#342).
+- TPIU: add `swo_supports` for checking what SWO configurations the target supports. (#381)
 - Add `std` and `serde` crate features for improved host-side ITM decode functionality when working with the downstream `itm`, `cargo-rtic-scope` crates (#363, #366).
 
 ## [v0.7.4] - 2021-12-31

--- a/src/peripheral/tpiu.rs
+++ b/src/peripheral/tpiu.rs
@@ -91,13 +91,13 @@ impl core::convert::TryFrom<u8> for TraceProtocol {
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct SWOSupports {
     /// Whether UART/NRZ encoding is supported for SWO.
-    nrz_encoding: bool,
+    pub nrz_encoding: bool,
     /// Whether Manchester encoding is supported for SWO.
-    manchester_encoding: bool,
+    pub manchester_encoding: bool,
     /// Whether parallel trace port operation is supported.
-    parallel_operation: bool,
+    pub parallel_operation: bool,
     /// The minimum implemented FIFO queue size of the TPIU for trace data.
-    min_queue_size: u8,
+    pub min_queue_size: u8,
 }
 
 impl TPIU {

--- a/src/peripheral/tpiu.rs
+++ b/src/peripheral/tpiu.rs
@@ -87,7 +87,8 @@ impl core::convert::TryFrom<u8> for TraceProtocol {
     }
 }
 
-/// The SWO options supported by the TPIU.
+/// The SWO options supported by the TPIU, and the mimimum size of the
+/// FIFO output queue for trace data.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct SWOSupports {
     /// Whether UART/NRZ encoding is supported for SWO.


### PR DESCRIPTION
A few small changes that I missed the first time around when the TPIU API was expanded.