### PR TITLE
deprecate `ptr()` function for the v0.7.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Deprecated
+- the `ptr()` function on all peripherals register blocks in favor of
+  the associated constant `PTR` (#386).
+
 ## [v0.7.4] - 2021-12-31
 
 ### Added

--- a/panic-itm/CHANGELOG.md
+++ b/panic-itm/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- changed `ITM::ptr()` to `ITM::PTR` as the `ptr()` functions are
+  deprecated (#386).
+
 ## [v0.4.2] - 2020-11-14
 
 - Support cortex-m v0.7.0

--- a/panic-itm/src/lib.rs
+++ b/panic-itm/src/lib.rs
@@ -46,7 +46,7 @@ use cortex_m::peripheral::ITM;
 fn panic(info: &PanicInfo) -> ! {
     interrupt::disable();
 
-    let itm = unsafe { &mut *ITM::ptr() };
+    let itm = unsafe { &mut *ITM::PTR };
     let stim = &mut itm.stim[0];
 
     iprintln!(stim, "{}", info);

--- a/src/itm.rs
+++ b/src/itm.rs
@@ -128,7 +128,7 @@ pub fn write_all(port: &mut Stim, buffer: &[u8]) {
 ///
 /// ```no_run
 /// # use cortex_m::{itm::{self, Aligned}, peripheral::ITM};
-/// # let port = unsafe { &mut (*ITM::ptr()).stim[0] };
+/// # let port = unsafe { &mut (*ITM::PTR).stim[0] };
 /// let mut buffer = Aligned([0; 14]);
 ///
 /// buffer.0.copy_from_slice(b"Hello, world!\n");

--- a/src/peripheral/cpuid.rs
+++ b/src/peripheral/cpuid.rs
@@ -122,7 +122,7 @@ impl CPUID {
     pub fn cache_dminline() -> u32 {
         const CTR_DMINLINE_POS: u32 = 16;
         const CTR_DMINLINE_MASK: u32 = 0xF << CTR_DMINLINE_POS;
-        let ctr = unsafe { (*Self::ptr()).ctr.read() };
+        let ctr = unsafe { (*Self::PTR).ctr.read() };
         (ctr & CTR_DMINLINE_MASK) >> CTR_DMINLINE_POS
     }
 
@@ -134,7 +134,7 @@ impl CPUID {
     pub fn cache_iminline() -> u32 {
         const CTR_IMINLINE_POS: u32 = 0;
         const CTR_IMINLINE_MASK: u32 = 0xF << CTR_IMINLINE_POS;
-        let ctr = unsafe { (*Self::ptr()).ctr.read() };
+        let ctr = unsafe { (*Self::PTR).ctr.read() };
         (ctr & CTR_IMINLINE_MASK) >> CTR_IMINLINE_POS
     }
 }

--- a/src/peripheral/dcb.rs
+++ b/src/peripheral/dcb.rs
@@ -53,7 +53,7 @@ impl DCB {
     pub fn is_debugger_attached() -> bool {
         unsafe {
             // do an 8-bit read of the 32-bit DHCSR register, and get the LSB
-            let value = ptr::read_volatile(Self::ptr() as *const u8);
+            let value = ptr::read_volatile(Self::PTR as *const u8);
             value & 0x1 == 1
         }
     }

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -77,7 +77,7 @@ impl DWT {
     #[inline]
     pub fn num_comp() -> u8 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::ptr()).ctrl.read() >> NUMCOMP_OFFSET) as u8 }
+        unsafe { ((*Self::PTR).ctrl.read() >> NUMCOMP_OFFSET) as u8 }
     }
 
     /// Returns `true` if the the implementation supports sampling and exception tracing
@@ -85,7 +85,7 @@ impl DWT {
     #[inline]
     pub fn has_exception_trace() -> bool {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).ctrl.read() & NOTRCPKT == 0 }
+        unsafe { (*Self::PTR).ctrl.read() & NOTRCPKT == 0 }
     }
 
     /// Returns `true` if the implementation includes external match signals
@@ -93,7 +93,7 @@ impl DWT {
     #[inline]
     pub fn has_external_match() -> bool {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).ctrl.read() & NOEXTTRIG == 0 }
+        unsafe { (*Self::PTR).ctrl.read() & NOEXTTRIG == 0 }
     }
 
     /// Returns `true` if the implementation supports a cycle counter
@@ -101,7 +101,7 @@ impl DWT {
     #[inline]
     pub fn has_cycle_counter() -> bool {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).ctrl.read() & NOCYCCNT == 0 }
+        unsafe { (*Self::PTR).ctrl.read() & NOCYCCNT == 0 }
     }
 
     /// Returns `true` if the implementation the profiling counters
@@ -109,7 +109,7 @@ impl DWT {
     #[inline]
     pub fn has_profiling_counter() -> bool {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).ctrl.read() & NOPRFCNT == 0 }
+        unsafe { (*Self::PTR).ctrl.read() & NOPRFCNT == 0 }
     }
 
     /// Enables the cycle counter
@@ -138,7 +138,7 @@ impl DWT {
     #[inline]
     pub fn cycle_counter_enabled() -> bool {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).ctrl.read() & CYCCNTENA != 0 }
+        unsafe { (*Self::PTR).ctrl.read() & CYCCNTENA != 0 }
     }
 
     /// Returns the current clock cycle count
@@ -157,7 +157,7 @@ impl DWT {
     #[inline]
     pub fn cycle_count() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).cyccnt.read() }
+        unsafe { (*Self::PTR).cyccnt.read() }
     }
 
     /// Set the cycle count
@@ -174,7 +174,7 @@ impl DWT {
     #[inline]
     pub fn unlock() {
         // NOTE(unsafe) atomic write to a stateless, write-only register
-        unsafe { (*Self::ptr()).lar.write(0xC5AC_CE55) }
+        unsafe { (*Self::PTR).lar.write(0xC5AC_CE55) }
     }
 
     /// Get the CPI count
@@ -188,7 +188,7 @@ impl DWT {
     #[inline]
     pub fn cpi_count() -> u8 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).cpicnt.read() as u8 }
+        unsafe { (*Self::PTR).cpicnt.read() as u8 }
     }
 
     /// Set the CPI count
@@ -203,7 +203,7 @@ impl DWT {
     #[inline]
     pub fn exception_count() -> u8 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).exccnt.read() as u8 }
+        unsafe { (*Self::PTR).exccnt.read() as u8 }
     }
 
     /// Set the exception count
@@ -224,7 +224,7 @@ impl DWT {
     #[inline]
     pub fn sleep_count() -> u8 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).sleepcnt.read() as u8 }
+        unsafe { (*Self::PTR).sleepcnt.read() as u8 }
     }
 
     /// Set the sleep count
@@ -239,7 +239,7 @@ impl DWT {
     #[inline]
     pub fn lsu_count() -> u8 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).lsucnt.read() as u8 }
+        unsafe { (*Self::PTR).lsucnt.read() as u8 }
     }
 
     /// Set the lsu count
@@ -256,7 +256,7 @@ impl DWT {
     #[inline]
     pub fn fold_count() -> u8 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).foldcnt.read() as u8 }
+        unsafe { (*Self::PTR).foldcnt.read() as u8 }
     }
 
     /// Set the folded instruction count

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -50,7 +50,7 @@
 //! } // all the peripheral singletons are destroyed here
 //!
 //! // actually safe because this is an atomic read with no side effects
-//! let cyccnt = unsafe { (*DWT::ptr()).cyccnt.read() };
+//! let cyccnt = unsafe { (*DWT::PTR).cyccnt.read() };
 //! ```
 //!
 //! # References
@@ -245,8 +245,9 @@ impl AC {
     /// Pointer to the register block
     pub const PTR: *const self::ac::RegisterBlock = 0xE000_EF90 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const self::ac::RegisterBlock {
         Self::PTR
     }
@@ -271,8 +272,9 @@ impl CBP {
     /// Pointer to the register block
     pub const PTR: *const self::cbp::RegisterBlock = 0xE000_EF50 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const self::cbp::RegisterBlock {
         Self::PTR
     }
@@ -299,8 +301,9 @@ impl CPUID {
     /// Pointer to the register block
     pub const PTR: *const self::cpuid::RegisterBlock = 0xE000_ED00 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const self::cpuid::RegisterBlock {
         Self::PTR
     }
@@ -326,8 +329,9 @@ impl DCB {
     /// Pointer to the register block
     pub const PTR: *const dcb::RegisterBlock = 0xE000_EDF0 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const dcb::RegisterBlock {
         Self::PTR
     }
@@ -353,8 +357,9 @@ impl DWT {
     /// Pointer to the register block
     pub const PTR: *const dwt::RegisterBlock = 0xE000_1000 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const dwt::RegisterBlock {
         Self::PTR
     }
@@ -381,8 +386,9 @@ impl FPB {
     /// Pointer to the register block
     pub const PTR: *const fpb::RegisterBlock = 0xE000_2000 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const fpb::RegisterBlock {
         Self::PTR
     }
@@ -410,8 +416,9 @@ impl FPU {
     /// Pointer to the register block
     pub const PTR: *const fpu::RegisterBlock = 0xE000_EF30 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const fpu::RegisterBlock {
         Self::PTR
     }
@@ -443,8 +450,9 @@ impl ICB {
     /// Pointer to the register block
     pub const PTR: *mut icb::RegisterBlock = 0xE000_E004 as *mut _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *mut icb::RegisterBlock {
         Self::PTR
     }
@@ -478,8 +486,9 @@ impl ITM {
     /// Pointer to the register block
     pub const PTR: *mut itm::RegisterBlock = 0xE000_0000 as *mut _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *mut itm::RegisterBlock {
         Self::PTR
     }
@@ -514,8 +523,9 @@ impl MPU {
     /// Pointer to the register block
     pub const PTR: *const mpu::RegisterBlock = 0xE000_ED90 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const mpu::RegisterBlock {
         Self::PTR
     }
@@ -541,8 +551,9 @@ impl NVIC {
     /// Pointer to the register block
     pub const PTR: *const nvic::RegisterBlock = 0xE000_E100 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const nvic::RegisterBlock {
         Self::PTR
     }
@@ -569,8 +580,9 @@ impl SAU {
     /// Pointer to the register block
     pub const PTR: *const sau::RegisterBlock = 0xE000_EDD0 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const sau::RegisterBlock {
         Self::PTR
     }
@@ -597,8 +609,9 @@ impl SCB {
     /// Pointer to the register block
     pub const PTR: *const scb::RegisterBlock = 0xE000_ED04 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const scb::RegisterBlock {
         Self::PTR
     }
@@ -624,8 +637,9 @@ impl SYST {
     /// Pointer to the register block
     pub const PTR: *const syst::RegisterBlock = 0xE000_E010 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const syst::RegisterBlock {
         Self::PTR
     }
@@ -652,8 +666,9 @@ impl TPIU {
     /// Pointer to the register block
     pub const PTR: *const tpiu::RegisterBlock = 0xE004_0000 as *const _;
 
-    /// Returns a pointer to the register block (to be deprecated in 0.7)
+    /// Returns a pointer to the register block
     #[inline(always)]
+    #[deprecated(since = "0.7.5", note = "Use the associated constant `PTR` instead")]
     pub const fn ptr() -> *const tpiu::RegisterBlock {
         Self::PTR
     }

--- a/src/peripheral/nvic.rs
+++ b/src/peripheral/nvic.rs
@@ -105,7 +105,7 @@ impl NVIC {
     {
         let nr = interrupt.number();
         // NOTE(unsafe) this is a write to a stateless register
-        unsafe { (*Self::ptr()).icer[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).icer[usize::from(nr / 32)].write(1 << (nr % 32)) }
     }
 
     /// Enables `interrupt`
@@ -118,7 +118,7 @@ impl NVIC {
     {
         let nr = interrupt.number();
         // NOTE(ptr) this is a write to a stateless register
-        (*Self::ptr()).iser[usize::from(nr / 32)].write(1 << (nr % 32))
+        (*Self::PTR).iser[usize::from(nr / 32)].write(1 << (nr % 32))
     }
 
     /// Returns the NVIC priority of `interrupt`
@@ -135,13 +135,13 @@ impl NVIC {
         {
             let nr = interrupt.number();
             // NOTE(unsafe) atomic read with no side effects
-            unsafe { (*Self::ptr()).ipr[usize::from(nr)].read() }
+            unsafe { (*Self::PTR).ipr[usize::from(nr)].read() }
         }
 
         #[cfg(armv6m)]
         {
             // NOTE(unsafe) atomic read with no side effects
-            let ipr_n = unsafe { (*Self::ptr()).ipr[Self::ipr_index(interrupt)].read() };
+            let ipr_n = unsafe { (*Self::PTR).ipr[Self::ipr_index(interrupt)].read() };
             let prio = (ipr_n >> Self::ipr_shift(interrupt)) & 0x0000_00ff;
             prio as u8
         }
@@ -158,7 +158,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::ptr()).iabr[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).iabr[usize::from(nr / 32)].read() & mask) == mask }
     }
 
     /// Checks if `interrupt` is enabled
@@ -171,7 +171,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::ptr()).iser[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).iser[usize::from(nr / 32)].read() & mask) == mask }
     }
 
     /// Checks if `interrupt` is pending
@@ -184,7 +184,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::ptr()).ispr[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).ispr[usize::from(nr / 32)].read() & mask) == mask }
     }
 
     /// Forces `interrupt` into pending state
@@ -196,7 +196,7 @@ impl NVIC {
         let nr = interrupt.number();
 
         // NOTE(unsafe) atomic stateless write; ICPR doesn't store any state
-        unsafe { (*Self::ptr()).ispr[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).ispr[usize::from(nr / 32)].write(1 << (nr % 32)) }
     }
 
     /// Sets the "priority" of `interrupt` to `prio`
@@ -242,7 +242,7 @@ impl NVIC {
         let nr = interrupt.number();
 
         // NOTE(unsafe) atomic stateless write; ICPR doesn't store any state
-        unsafe { (*Self::ptr()).icpr[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).icpr[usize::from(nr / 32)].write(1 << (nr % 32)) }
     }
 
     #[cfg(armv6m)]

--- a/src/peripheral/scb.rs
+++ b/src/peripheral/scb.rs
@@ -137,7 +137,7 @@ impl SCB {
     #[inline]
     pub fn fpu_access_mode() -> FpuAccessMode {
         // NOTE(unsafe) atomic read operation with no side effects
-        let cpacr = unsafe { (*Self::ptr()).cpacr.read() };
+        let cpacr = unsafe { (*Self::PTR).cpacr.read() };
 
         if cpacr & SCB_CPACR_FPU_MASK == SCB_CPACR_FPU_ENABLE | SCB_CPACR_FPU_USER {
             FpuAccessMode::Enabled
@@ -170,7 +170,7 @@ impl SCB {
     /// Returns the active exception number
     #[inline]
     pub fn vect_active() -> VectActive {
-        let icsr = unsafe { ptr::read(&(*SCB::ptr()).icsr as *const _ as *const u32) };
+        let icsr = unsafe { ptr::read(&(*SCB::PTR).icsr as *const _ as *const u32) };
 
         match icsr as u8 {
             0 => VectActive::ThreadMode,
@@ -378,7 +378,7 @@ impl SCB {
         crate::asm::isb();
 
         // NOTE(unsafe): atomic read with no side effects
-        unsafe { (*Self::ptr()).ccr.read() & SCB_CCR_IC_MASK == SCB_CCR_IC_MASK }
+        unsafe { (*Self::PTR).ccr.read() & SCB_CCR_IC_MASK == SCB_CCR_IC_MASK }
     }
 
     /// Invalidates the entire I-cache.
@@ -448,7 +448,7 @@ impl SCB {
         crate::asm::isb();
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).ccr.read() & SCB_CCR_DC_MASK == SCB_CCR_DC_MASK }
+        unsafe { (*Self::PTR).ccr.read() & SCB_CCR_DC_MASK == SCB_CCR_DC_MASK }
     }
 
     /// Invalidates the entire D-cache.
@@ -847,7 +847,7 @@ impl SCB {
     pub fn sys_reset() -> ! {
         crate::asm::dsb();
         unsafe {
-            (*Self::ptr()).aircr.modify(
+            (*Self::PTR).aircr.modify(
                 |r| {
                     SCB_AIRCR_VECTKEY | // otherwise the write is ignored
             r & SCB_AIRCR_PRIGROUP_MASK | // keep priority group unchanged
@@ -874,21 +874,21 @@ impl SCB {
     #[inline]
     pub fn set_pendsv() {
         unsafe {
-            (*Self::ptr()).icsr.write(SCB_ICSR_PENDSVSET);
+            (*Self::PTR).icsr.write(SCB_ICSR_PENDSVSET);
         }
     }
 
     /// Check if PENDSVSET bit in the ICSR register is set meaning PendSV interrupt is pending
     #[inline]
     pub fn is_pendsv_pending() -> bool {
-        unsafe { (*Self::ptr()).icsr.read() & SCB_ICSR_PENDSVSET == SCB_ICSR_PENDSVSET }
+        unsafe { (*Self::PTR).icsr.read() & SCB_ICSR_PENDSVSET == SCB_ICSR_PENDSVSET }
     }
 
     /// Set the PENDSVCLR bit in the ICSR register which will clear a pending PendSV interrupt
     #[inline]
     pub fn clear_pendsv() {
         unsafe {
-            (*Self::ptr()).icsr.write(SCB_ICSR_PENDSVCLR);
+            (*Self::PTR).icsr.write(SCB_ICSR_PENDSVCLR);
         }
     }
 
@@ -896,21 +896,21 @@ impl SCB {
     #[inline]
     pub fn set_pendst() {
         unsafe {
-            (*Self::ptr()).icsr.write(SCB_ICSR_PENDSTSET);
+            (*Self::PTR).icsr.write(SCB_ICSR_PENDSTSET);
         }
     }
 
     /// Check if PENDSTSET bit in the ICSR register is set meaning SysTick interrupt is pending
     #[inline]
     pub fn is_pendst_pending() -> bool {
-        unsafe { (*Self::ptr()).icsr.read() & SCB_ICSR_PENDSTSET == SCB_ICSR_PENDSTSET }
+        unsafe { (*Self::PTR).icsr.read() & SCB_ICSR_PENDSTSET == SCB_ICSR_PENDSTSET }
     }
 
     /// Set the PENDSTCLR bit in the ICSR register which will clear a pending SysTick interrupt
     #[inline]
     pub fn clear_pendst() {
         unsafe {
-            (*Self::ptr()).icsr.write(SCB_ICSR_PENDSTCLR);
+            (*Self::PTR).icsr.write(SCB_ICSR_PENDSTCLR);
         }
     }
 }
@@ -966,7 +966,7 @@ impl SCB {
 
             // NOTE(unsafe): Index is bounded to [4,15] by SystemHandler design.
             // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
-            let priority_ref = unsafe { (*Self::ptr()).shpr.get_unchecked(usize::from(index - 4)) };
+            let priority_ref = unsafe { (*Self::PTR).shpr.get_unchecked(usize::from(index - 4)) };
 
             priority_ref.read()
         }
@@ -978,7 +978,7 @@ impl SCB {
             // NOTE(unsafe): Index is bounded to [11,15] by SystemHandler design.
             // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
             let priority_ref = unsafe {
-                (*Self::ptr())
+                (*Self::PTR)
                     .shpr
                     .get_unchecked(usize::from((index - 8) / 4))
             };
@@ -1009,7 +1009,7 @@ impl SCB {
         {
             // NOTE(unsafe): Index is bounded to [4,15] by SystemHandler design.
             // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
-            let priority_ref = (*Self::ptr()).shpr.get_unchecked(usize::from(index - 4));
+            let priority_ref = (*Self::PTR).shpr.get_unchecked(usize::from(index - 4));
 
             priority_ref.write(prio)
         }
@@ -1018,7 +1018,7 @@ impl SCB {
         {
             // NOTE(unsafe): Index is bounded to [11,15] by SystemHandler design.
             // TODO: Review it after rust-lang/rust/issues/13926 will be fixed.
-            let priority_ref = (*Self::ptr())
+            let priority_ref = (*Self::PTR)
                 .shpr
                 .get_unchecked(usize::from((index - 8) / 4));
 

--- a/src/peripheral/syst.rs
+++ b/src/peripheral/syst.rs
@@ -98,14 +98,14 @@ impl SYST {
     #[inline]
     pub fn get_current() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).cvr.read() }
+        unsafe { (*Self::PTR).cvr.read() }
     }
 
     /// Gets reload value
     #[inline]
     pub fn get_reload() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).rvr.read() }
+        unsafe { (*Self::PTR).rvr.read() }
     }
 
     /// Returns the reload value with which the counter would wrap once per 10
@@ -116,14 +116,14 @@ impl SYST {
     #[inline]
     pub fn get_ticks_per_10ms() -> u32 {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).calib.read() & SYST_COUNTER_MASK }
+        unsafe { (*Self::PTR).calib.read() & SYST_COUNTER_MASK }
     }
 
     /// Checks if an external reference clock is available
     #[inline]
     pub fn has_reference_clock() -> bool {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).calib.read() & SYST_CALIB_NOREF == 0 }
+        unsafe { (*Self::PTR).calib.read() & SYST_CALIB_NOREF == 0 }
     }
 
     /// Checks if the counter wrapped (underflowed) since the last check
@@ -161,7 +161,7 @@ impl SYST {
     #[inline]
     pub fn is_precise() -> bool {
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { (*Self::ptr()).calib.read() & SYST_CALIB_SKEW == 0 }
+        unsafe { (*Self::PTR).calib.read() & SYST_CALIB_SKEW == 0 }
     }
 
     /// Sets clock source

--- a/src/peripheral/test.rs
+++ b/src/peripheral/test.rs
@@ -1,6 +1,6 @@
 #[test]
 fn cpuid() {
-    let cpuid = unsafe { &*crate::peripheral::CPUID::ptr() };
+    let cpuid = unsafe { &*crate::peripheral::CPUID::PTR };
 
     assert_eq!(address(&cpuid.base), 0xE000_ED00);
     assert_eq!(address(&cpuid.pfr), 0xE000_ED40);
@@ -16,7 +16,7 @@ fn cpuid() {
 
 #[test]
 fn dcb() {
-    let dcb = unsafe { &*crate::peripheral::DCB::ptr() };
+    let dcb = unsafe { &*crate::peripheral::DCB::PTR };
 
     assert_eq!(address(&dcb.dhcsr), 0xE000_EDF0);
     assert_eq!(address(&dcb.dcrsr), 0xE000_EDF4);
@@ -26,7 +26,7 @@ fn dcb() {
 
 #[test]
 fn dwt() {
-    let dwt = unsafe { &*crate::peripheral::DWT::ptr() };
+    let dwt = unsafe { &*crate::peripheral::DWT::PTR };
 
     assert_eq!(address(&dwt.ctrl), 0xE000_1000);
     #[cfg(not(armv6m))]
@@ -56,7 +56,7 @@ fn dwt() {
 
 #[test]
 fn fpb() {
-    let fpb = unsafe { &*crate::peripheral::FPB::ptr() };
+    let fpb = unsafe { &*crate::peripheral::FPB::PTR };
 
     assert_eq!(address(&fpb.ctrl), 0xE000_2000);
     assert_eq!(address(&fpb.remap), 0xE000_2004);
@@ -68,7 +68,7 @@ fn fpb() {
 
 #[test]
 fn fpu() {
-    let fpu = unsafe { &*crate::peripheral::FPU::ptr() };
+    let fpu = unsafe { &*crate::peripheral::FPU::PTR };
 
     assert_eq!(address(&fpu.fpccr), 0xE000_EF34);
     assert_eq!(address(&fpu.fpcar), 0xE000_EF38);
@@ -80,7 +80,7 @@ fn fpu() {
 
 #[test]
 fn itm() {
-    let itm = unsafe { &*crate::peripheral::ITM::ptr() };
+    let itm = unsafe { &*crate::peripheral::ITM::PTR };
 
     assert_eq!(address(&itm.stim), 0xE000_0000);
     assert_eq!(address(&itm.ter), 0xE000_0E00);
@@ -92,7 +92,7 @@ fn itm() {
 
 #[test]
 fn mpu() {
-    let mpu = unsafe { &*crate::peripheral::MPU::ptr() };
+    let mpu = unsafe { &*crate::peripheral::MPU::PTR };
 
     assert_eq!(address(&mpu._type), 0xE000ED90);
     assert_eq!(address(&mpu.ctrl), 0xE000ED94);
@@ -109,7 +109,7 @@ fn mpu() {
 
 #[test]
 fn nvic() {
-    let nvic = unsafe { &*crate::peripheral::NVIC::ptr() };
+    let nvic = unsafe { &*crate::peripheral::NVIC::PTR };
 
     assert_eq!(address(&nvic.iser), 0xE000E100);
     assert_eq!(address(&nvic.icer), 0xE000E180);
@@ -123,7 +123,7 @@ fn nvic() {
 
 #[test]
 fn scb() {
-    let scb = unsafe { &*crate::peripheral::SCB::ptr() };
+    let scb = unsafe { &*crate::peripheral::SCB::PTR };
 
     assert_eq!(address(&scb.icsr), 0xE000_ED04);
     assert_eq!(address(&scb.vtor), 0xE000_ED08);
@@ -143,7 +143,7 @@ fn scb() {
 
 #[test]
 fn syst() {
-    let syst = unsafe { &*crate::peripheral::SYST::ptr() };
+    let syst = unsafe { &*crate::peripheral::SYST::PTR };
 
     assert_eq!(address(&syst.csr), 0xE000_E010);
     assert_eq!(address(&syst.rvr), 0xE000_E014);
@@ -153,7 +153,7 @@ fn syst() {
 
 #[test]
 fn tpiu() {
-    let tpiu = unsafe { &*crate::peripheral::TPIU::ptr() };
+    let tpiu = unsafe { &*crate::peripheral::TPIU::PTR };
 
     assert_eq!(address(&tpiu.sspsr), 0xE004_0000);
     assert_eq!(address(&tpiu.cspsr), 0xE004_0004);


### PR DESCRIPTION
Deprecating `ptr()` in `v0.7.x` series per #370