### PR TITLE
Fix most clippy lints

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -3,9 +3,9 @@ delete_merged_branches = true
 required_approvals = 1
 status = [
   "ci-linux (stable)",
-  "ci-linux (1.40.0)",
+  "ci-linux (1.42.0)",
   "rt-ci-linux (stable)",
-  "rt-ci-linux (1.40.0)",
+  "rt-ci-linux (1.42.0)",
   "rt-ci-other-os (macOS-latest)",
   "rt-ci-other-os (windows-latest)",
   "rustfmt",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.40.0
+          - rust: 1.42.0
 
           # Test nightly but don't fail
           - rust: nightly

--- a/.github/workflows/rt-ci.yml
+++ b/.github/workflows/rt-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # All generated code should be running on stable now
-        rust: [nightly, stable, 1.40.0]
+        rust: [nightly, stable, 1.42.0]
 
         include:
           # Nightly is only for reference and allowed to fail

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is developed and maintained by the [Cortex-M team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.40 and up. It might compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.42 and up. It might compile with older versions but that may change in any new patch release.
 
 ## License
 

--- a/cortex-m-rt/README.md
+++ b/cortex-m-rt/README.md
@@ -11,7 +11,7 @@ This project is developed and maintained by the [Cortex-M team][team].
 
 # Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.40.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.42.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 # License

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -159,7 +159,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             Exception::DefaultHandler | Exception::HardFault | Exception::NonMaskableInt => {
                 // These are unsafe to define.
                 let name = if exn == Exception::DefaultHandler {
-                    format!("`DefaultHandler`")
+                    "`DefaultHandler`".to_string()
                 } else {
                     format!("`{:?}` handler", exn)
                 };
@@ -557,7 +557,7 @@ fn extract_static_muts(
     let mut seen = HashSet::new();
     let mut statics = vec![];
     let mut stmts = vec![];
-    while let Some(stmt) = istmts.next() {
+    for stmt in istmts.by_ref() {
         match stmt {
             Stmt::Item(Item::Static(var)) => {
                 if var.mutability.is_some() {
@@ -622,7 +622,7 @@ fn check_attr_whitelist(attrs: &[Attribute], caller: WhiteListCaller) -> Result<
 
     'o: for attr in attrs {
         for val in whitelist {
-            if eq(&attr, &val) {
+            if eq(attr, val) {
                 continue 'o;
             }
         }

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -28,10 +28,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         && f.sig.variadic.is_none()
         && match f.sig.output {
             ReturnType::Default => false,
-            ReturnType::Type(_, ref ty) => match **ty {
-                Type::Never(_) => true,
-                _ => false,
-            },
+            ReturnType::Type(_, ref ty) => matches!(**ty, Type::Never(_)),
         };
 
     if !valid_signature {
@@ -252,10 +249,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                 && f.sig.variadic.is_none()
                 && match f.sig.output {
                     ReturnType::Default => false,
-                    ReturnType::Type(_, ref ty) => match **ty {
-                        Type::Never(_) => true,
-                        _ => false,
-                    },
+                    ReturnType::Type(_, ref ty) => matches!(**ty, Type::Never(_)),
                 };
 
             if !valid_signature {

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -418,7 +418,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! The MSRV of this release is Rust 1.40.0.
+//! The MSRV of this release is Rust 1.42.0.
 
 // # Developer notes
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.40 and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.42 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 
 #![cfg_attr(feature = "inline-asm", feature(asm))]

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -232,7 +232,7 @@ pub fn check_host_side() {
     {
         let a = VectActive::from(19).unwrap();
         let b = VectActive::from(20).unwrap();
-        assert_eq!(a < b, true);
+        assert!(a < b);
     }
 
     // check TryFrom
@@ -240,7 +240,7 @@ pub fn check_host_side() {
         use core::convert::TryInto;
         use std::convert::TryFrom;
 
-        let lts: LocalTimestampOptions = (16 as u8).try_into().unwrap();
+        let lts: LocalTimestampOptions = (16_u8).try_into().unwrap();
         assert_eq!(lts, LocalTimestampOptions::EnabledDiv16);
 
         assert!(LocalTimestampOptions::try_from(42).is_err());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,8 +2,8 @@ use std::{env, process};
 use xtask::{assemble_blobs, check_blobs, check_host_side};
 
 fn main() {
-    let subcommand = env::args().skip(1).next();
-    match subcommand.as_ref().map(|s| &**s) {
+    let subcommand = env::args().nth(1);
+    match subcommand.as_deref() {
         Some("assemble") => assemble_blobs(),
         Some("check-blobs") => check_blobs(),
         Some("check-host-side") => check_host_side(),


### PR DESCRIPTION
This fixes all clippy lints that do not result in a user-visible change, and result in valid code for the 1.40 MSRV.