### PR TITLE
Fix #414, use fully qualified path for `exception` enum in `#[exception]` macro

### DIFF
--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Fixes
+
+- Fix `cortex_m_rt::exception` macro no longer being usable fully-qualified ([#414])
+
+[#414]: https://github.com/rust-embedded/cortex-m/issues/414
+
+## Notes
+
+- From this release onwards, cortex-m-rt lives in the cortex-m repository;
+  issue numbers refer there.
+
 ## [v0.7.1]
 
 ## Fixes

--- a/cortex-m-rt/Cargo.toml
+++ b/cortex-m-rt/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/rust-embedded/cortex-m"
 version = "0.7.1"
 autoexamples = true
 links = "cortex-m-rt" # Prevent multiple versions of cortex-m-rt being linked
+edition = "2018"
 
 [dependencies]
 cortex-m-rt-macros = { path = "macros", version = "=0.7.0" }

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -328,7 +328,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             f.block.stmts = iter::once(
                 syn::parse2(quote! {{
                     // check that this exception actually exists
-                    exception::#ident;
+                    cortex_m_rt::exception::#ident;
                 }})
                 .unwrap(),
             )

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -174,7 +174,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
         Exception::Other => {
             quote! {
                 const _: () = {
-                    let _ = cortex_m_rt::Exception::#ident;
+                    let _ = ::cortex_m_rt::Exception::#ident;
                 };
             }
         }
@@ -328,7 +328,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             f.block.stmts = iter::once(
                 syn::parse2(quote! {{
                     // check that this exception actually exists
-                    cortex_m_rt::exception::#ident;
+                    ::cortex_m_rt::exception::#ident;
                 }})
                 .unwrap(),
             )


### PR DESCRIPTION
Partially reverts https://github.com/rust-embedded/cortex-m-rt/pull/224
to continue to use a fully-qualified path to `exception`.