### PR TITLE
Exclude c-m-rt from cron test of cortex-m, fixes #417

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,7 +16,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Run tests
-        run: cargo test --all
+        run: cargo test --all --exclude cortex-m-rt
       - uses: imjohnbo/issue-bot@v2
         if: failure()
         with:


### PR DESCRIPTION
Excludes cortex-m-rt from the plain ci-linux cron CI. We already test cortex-m-rt separate in rt-ci-linux, and plain `cargo test` doesn't work on x86 for cortex-m-rt.

Fixes #417 which is where this week's cron run failed.