### PR TITLE
Allow #[naked] attribute on interrupt handlers and pre_init

### DIFF
--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -612,6 +612,7 @@ fn check_attr_whitelist(attrs: &[Attribute], caller: WhiteListCaller) -> Result<
         "deny",
         "forbid",
         "cold",
+        "naked",
     ];
 
     'o: for attr in attrs {


### PR DESCRIPTION
Might be useful for `pre_init` especially, now that constrained naked functions are hopefully [on the road to being stable](https://github.com/rust-lang/rust/issues/90957).

`pre_init` and `entry` are called from our `asm.S` via `bl __pre_init` and `bl main`, exception and interrupt handlers are called directly by the CPU; in either case there's no issue with calling a naked function.

Inspired by https://twitter.com/the6p4c/status/1489266955232034817