### PR TITLE
Prepare for c-m-sh v0.4.2, p-sh v0.6.0

### DIFF
--- a/cortex-m-semihosting/CHANGELOG.md
+++ b/cortex-m-semihosting/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.0] - 2022-03-01
+
 - Always use inline-asm, requiring Rust 1.59.
 - Removed inline-asm feature.
 
@@ -144,7 +146,8 @@ change.
 
 - Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.4.1...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.5.0...HEAD
+[v0.5.0]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.4.1...c-m-sh-v0.5.0
 [v0.4.1]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.4.0...c-m-sh-v0.4.1
 [v0.4.0]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.3.5...c-m-sh-v0.4.0
 [v0.3.7]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.6...v0.3.7

--- a/cortex-m-semihosting/Cargo.toml
+++ b/cortex-m-semihosting/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-semihosting"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.59"
 

--- a/panic-semihosting/CHANGELOG.md
+++ b/panic-semihosting/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.6.0] - 2022-03-01
+
 - Always use inline-asm, requiring Rust 1.59.
 - Remove inline-asm feature.
 
@@ -72,7 +74,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/p-sh-v0.5.6...HEAD
+[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/p-sh-v0.6.0...HEAD
+[v0.6.0]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.5.6...p-sh-v0.6.0
 [v0.5.6]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.5.5...p-sh-v0.5.6
 [v0.5.5]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.5.4...p-sh-v0.5.5
 [v0.5.4]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.5.3...p-sh-v0.5.4

--- a/panic-semihosting/Cargo.toml
+++ b/panic-semihosting/Cargo.toml
@@ -10,13 +10,13 @@ keywords = ["panic-handler", "panic-impl", "panic", "semihosting"]
 license = "MIT OR Apache-2.0"
 name = "panic-semihosting"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.5.6"
+version = "0.6.0"
 rust-version = "1.59"
 edition = "2021"
 
 [dependencies]
 cortex-m = { path = "..", version = ">= 0.5.6, < 0.8" }
-cortex-m-semihosting = { path = "../cortex-m-semihosting", version = ">= 0.3, < 0.5" }
+cortex-m-semihosting = { path = "../cortex-m-semihosting", version = ">= 0.5.0, < 0.6" }
 
 [features]
 exit = []


### PR DESCRIPTION
This PR prepares for a release of cortex-m-semihosting 0.4.2 and panic-semihosting 0.6.0. Since we never had a non-yanked 0.4.x version of cortex-m-semihosting, this is essentially a new breaking release for both crates. The main change is the use of the new asm macro, with the removal of the inline-asm feature and bumped MSRV.