### PR TITLE
Remove prelude.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@ pub mod interrupt;
 #[cfg(all(not(armv6m), not(armv8m_base)))]
 pub mod itm;
 pub mod peripheral;
-pub mod prelude;
 pub mod register;
 
 pub use crate::peripheral::Peripherals;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,0 @@
-//! Prelude
-
-pub use embedded_hal::prelude::*;


### PR DESCRIPTION
Hoping to sneak this in before 0.8 :)

The prelude just reexports all of `embedded-hal 0.2`'s prelude. With EH1.0 around the corner it would be a shame to get stuck with 0.2 in the prelude, and changing it later is a breaking change.

Also, EH1.0 has removed the prelude.