### PR TITLE
Exclude testsuite from cron, fixes #427

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,7 +16,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Run tests
-        run: cargo test --all --exclude cortex-m-rt
+        run: cargo test --all --exclude cortex-m-rt --exclude testsuite
       - uses: imjohnbo/issue-bot@v2
         if: failure()
         with:


### PR DESCRIPTION
Turns out #427 was caused by #355 after all, because the CI workflow was updated to exclude testsuite from its default `cargo test`, but the cron workflow wasn't.

For now this seems like the simplest fix; eventually it might be nice to have cron run the testsuite too (at least in qemu), but really cron's there to catch surprise compilation failures when new Rust versions or new dependency releases come out, so I don't think it's urgent.