### PR TITLE
rt: fix veneer limit position in linker script

### DIFF
--- a/cortex-m-rt/link.x.in
+++ b/cortex-m-rt/link.x.in
@@ -144,8 +144,12 @@ SECTIONS
     __veneer_base = .;
     *(.gnu.sgstubs*)
     . = ALIGN(32);
-    __veneer_limit = .;
   } > FLASH
+  /* Place `__veneer_limit` outside the `.gnu.sgstubs` section because veneers are
+   * always inserted last in the section, which would otherwise be _after_ the `__veneer_limit` symbol.
+   */
+  . = ALIGN(32);
+  __veneer_limit = .;
 
   /* ### .bss */
   .bss (NOLOAD) : ALIGN(4)


### PR DESCRIPTION
This pull request fixes a CMSE related bug. If we define `#[cmse_nonsecure_call]` segments it would generate functions in `.gnu.sgstubs`, but we would eventually found out that for unknown reason `__veneer_base` == `__veneer_limit`, where SAU configuration to this segment would be impossible.
The reason for this bug is unknown, but after this pull request it would link into correct limit value.

I wrote an example for this fix: https://github.com/IoTS-P/trustzone-m-rs/tree/sgstub-fixed . Before this pull request, this project builds but it would print like `SG function stub region is at 0x10005fc0 .. 0x10005fc0`, resulting in secure fault. After this pull request, it would print `SG function stub region is at 0x10005fc0 .. 0x10005fe0` and runs successfully.