### PR TITLE
ci: update github-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - rust: nightly
             experimental: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,11 +8,11 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'pull_request_target'
         with:
           ref: refs/pull/${{ github.event.number }}/head
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,7 +9,7 @@ jobs:
   ci-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -17,7 +17,7 @@ jobs:
           override: true
       - name: Run tests
         run: cargo test --all --exclude cortex-m-rt --exclude testsuite
-      - uses: imjohnbo/issue-bot@v2
+      - uses: imjohnbo/issue-bot@v3
         if: failure()
         with:
           title: CI Failure
@@ -36,7 +36,7 @@ jobs:
       run:
         working-directory: cortex-m-rt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -62,7 +62,7 @@ jobs:
         run: TARGET=thumbv8m.main-none-eabi TRAVIS_RUST_VERSION=stable bash ci/script.sh
       - name: Run CI script for thumbv8m.main-none-eabihf under stable
         run: TARGET=thumbv8m.main-none-eabihf TRAVIS_RUST_VERSION=stable bash ci/script.sh
-      - uses: imjohnbo/issue-bot@v2
+      - uses: imjohnbo/issue-bot@v3
         if: failure()
         with:
           title: CI Failure

--- a/.github/workflows/on-target.yml
+++ b/.github/workflows/on-target.yml
@@ -12,7 +12,7 @@ jobs:
   hil-qemu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -37,7 +37,7 @@ jobs:
   hil-compile-rtt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -53,7 +53,7 @@ jobs:
           RUSTFLAGS: -C link-arg=-Tlink.x -D warnings
         run: cargo build -p testsuite --target thumbv6m-none-eabi --features testsuite/rtt
       - name: Upload testsuite binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: testsuite-bin
           if-no-files-found: error
@@ -65,12 +65,12 @@ jobs:
     needs:
       - hil-compile-rtt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Display probe-run version
         run: probe-run --version
       - name: List probes
         run: probe-run --list-probes
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: testsuite-bin
           path: testsuite-bin

--- a/.github/workflows/rt-ci.yml
+++ b/.github/workflows/rt-ci.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         working-directory: cortex-m-rt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -60,7 +60,7 @@ jobs:
       run:
         working-directory: cortex-m-rt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -10,7 +10,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
* actions/checkout 2 -> 3
* actions/download-artifact 2 -> 3
* actions/upload-artifact 2 -> 3
* imjonbo/issue-bot 2 -> 3

This fixes on-target CI.  The self-hosted runner updated and removed node v12, because it is EOL and no longer receiving security updates.

* `actions` changes do not break anything, they just update node.
* `issue-bot` has breaking changes, but I do not think they apply: [release notes](https://github.com/imjohnbo/issue-bot/releases/tag/v3.0.0)