### PR TITLE
Allow calling `interrupt::free` with zero-arity closures. (0.7.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- `interrupt::free` can be called with closures of type `FnOnce() -> T`.
+
 ### Deprecated
 - the `ptr()` function on all peripherals register blocks in favor of
   the associated constant `PTR` (#386).
+- Calling `interrupt::free` with closures of type `FnOnce(&CriticalSection) -> T` is deprecated. Users should switch to using `critical_section::with`.
 
 ## [v0.7.4] - 2021-12-31
 

--- a/cortex-m-semihosting/src/export.rs
+++ b/cortex-m-semihosting/src/export.rs
@@ -9,7 +9,7 @@ use crate::hio::{self, HostStream};
 static mut HSTDOUT: Option<HostStream> = None;
 
 pub fn hstdout_str(s: &str) {
-    let _result = interrupt::free(|_| unsafe {
+    let _result = interrupt::free(|| unsafe {
         if HSTDOUT.is_none() {
             HSTDOUT = Some(hio::hstdout()?);
         }
@@ -19,7 +19,7 @@ pub fn hstdout_str(s: &str) {
 }
 
 pub fn hstdout_fmt(args: fmt::Arguments) {
-    let _result = interrupt::free(|_| unsafe {
+    let _result = interrupt::free(|| unsafe {
         if HSTDOUT.is_none() {
             HSTDOUT = Some(hio::hstdout()?);
         }
@@ -31,7 +31,7 @@ pub fn hstdout_fmt(args: fmt::Arguments) {
 static mut HSTDERR: Option<HostStream> = None;
 
 pub fn hstderr_str(s: &str) {
-    let _result = interrupt::free(|_| unsafe {
+    let _result = interrupt::free(|| unsafe {
         if HSTDERR.is_none() {
             HSTDERR = Some(hio::hstderr()?);
         }
@@ -41,7 +41,7 @@ pub fn hstderr_str(s: &str) {
 }
 
 pub fn hstderr_fmt(args: fmt::Arguments) {
-    let _result = interrupt::free(|_| unsafe {
+    let _result = interrupt::free(|| unsafe {
         if HSTDERR.is_none() {
             HSTDERR = Some(hio::hstderr()?);
         }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -56,6 +56,7 @@ pub unsafe fn enable() {
 /// https://geo-ant.github.io/blog/2021/rust-traits-and-variadic-functions/
 ///
 /// TODO: Remove before releasing 0.8.
+#[doc(hidden)]
 pub trait InterruptFreeFn<Args, R> {
     /// Call the closure.
     unsafe fn call(self) -> R;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,6 @@
 // Don't warn about feature(asm) being stable on Rust >= 1.59.0
 #![allow(stable_features)]
 
-extern crate bare_metal;
-extern crate volatile_register;
-
 #[macro_use]
 mod call_asm;
 #[macro_use]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,7 +54,7 @@ macro_rules! iprintln {
 #[macro_export]
 macro_rules! singleton {
     (: $ty:ty = $expr:expr) => {
-        $crate::interrupt::free(|_| {
+        $crate::interrupt::free(|| {
             static mut VAR: Option<$ty> = None;
 
             #[allow(unsafe_code)]

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -165,7 +165,7 @@ impl Peripherals {
     /// Returns all the core peripherals *once*
     #[inline]
     pub fn take() -> Option<Self> {
-        interrupt::free(|_| {
+        interrupt::free(|| {
             if unsafe { TAKEN } {
                 None
             } else {

--- a/src/peripheral/sau.rs
+++ b/src/peripheral/sau.rs
@@ -162,7 +162,7 @@ impl SAU {
     /// This function is executed under a critical section to prevent having inconsistent results.
     #[inline]
     pub fn set_region(&mut self, region_number: u8, region: SauRegion) -> Result<(), SauError> {
-        interrupt::free(|_| {
+        interrupt::free(|| {
             let base_address = region.base_address;
             let limit_address = region.limit_address;
             let attribute = region.attribute;
@@ -215,7 +215,7 @@ impl SAU {
     /// This function is executed under a critical section to prevent having inconsistent results.
     #[inline]
     pub fn get_region(&mut self, region_number: u8) -> Result<SauRegion, SauError> {
-        interrupt::free(|_| {
+        interrupt::free(|| {
             if region_number >= self.region_numbers() {
                 Err(SauError::RegionNumberTooBig)
             } else {


### PR DESCRIPTION
0.8 will only accept zero-arity closures, this will make the transition a bit easier by being able to update calls before it is released.