### PR TITLE
Prepare for v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -746,7 +746,8 @@ fn main() {
 - Functions to get the vector table
 - Wrappers over miscellaneous instructions like `bkpt`
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.4...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.5...HEAD
+[v0.7.5]: https://github.com/rust-embedded/cortex-m/compare/v0.7.4...v0.7.5
 [v0.7.4]: https://github.com/rust-embedded/cortex-m/compare/v0.7.3...v0.7.4
 [v0.7.3]: https://github.com/rust-embedded/cortex-m/compare/v0.7.2...v0.7.3
 [v0.7.2]: https://github.com/rust-embedded/cortex-m/compare/v0.7.1...v0.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.7.5] - 2022-05-15
+
 ### Deprecated
 - the `ptr()` function on all peripherals register blocks in favor of
   the associated constant `PTR` (#386).
+
+### Changed
+
+- The `inline-asm` feature no longer requires a nightly Rust compiler, but
+  does require Rust 1.59 or above.
 
 ## [v0.7.4] - 2021-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `inline-asm` feature no longer requires a nightly Rust compiler, but
   does require Rust 1.59 or above.
 
+### Fixed
+- Fixed `singleton!()` statics sometimes ending up in `.data` instead of `.bss` (#364, #380).
+  (Backported from upcoming 0.8 release).
+
 ## [v0.7.4] - 2021-12-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2018"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@
 //! - Some of the `register` API only becomes available only when `inline-asm` is enabled. Check the
 //! API docs for details.
 //!
-//! The disadvantage is that `inline-asm` requires a nightly toolchain.
+//! The disadvantage is that `inline-asm` requires a Rust version at least 1.59 to use the `asm!()`
+//! macro. In the future 0.8 and above versions of `cortex-m`, this feature will always be enabled.
 //!
 //! ## `cm7-r0p1`
 //!
@@ -55,7 +56,6 @@
 //! This crate is guaranteed to compile on stable Rust 1.38 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 
-#![cfg_attr(feature = "inline-asm", feature(asm))]
 #![deny(missing_docs)]
 #![no_std]
 #![allow(clippy::identity_op)]


### PR DESCRIPTION
Currently with cortex-m 0.7.4 it's not possible for stable Rust users to enable the inline-asm feature, even though their compiler might support it, because of the `![cfg_attr(feature = "inline-asm", feature(asm))]` line. I propose a new 0.7.5 release that removes this line, which means users on stable Rust >=1.59 could enable the previously nightly-only feature to get stable inline asm.

I wouldn't enable the feature by default, because that would be a significant MSRV bump, but at least this way more users could enable it before we release 0.8 with the revamped and inline-only asm.

I've also backported the bugfix from #380 which I don't believe is a breaking change.

I haven't had a chance to test this yet so it would be great if someone could try it out and just make sure the inline-asm feature does work before merging.

Any thoughts on anything else worth backporting from 0.8?