### PR TITLE
Support for embedded_hal 1.0.0-alpha.8 in addition to 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ bare-metal = "1"
 volatile-register = "0.2.0"
 bitfield = "0.13.2"
 embedded-hal = "0.2.4"
+eh1_0_alpha = { version = "=1.0.0-alpha.8", package="embedded-hal", optional=true }
+
 
 [dependencies.serde]
 version = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+# Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+
 [package]
 authors = [
     "The Cortex-M Team <cortex-m@teams.rust-embedded.org>",

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,6 +1,11 @@
 //! A delay driver based on SysTick.
 
 use crate::peripheral::{syst::SystClkSource, SYST};
+#[cfg(feature = "eh1_0_alpha")]
+use core::convert::Infallible;
+
+#[cfg(feature = "eh1_0_alpha")]
+use eh1_0_alpha::delay::blocking::DelayUs as EH1DelayUs;
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 
 /// System timer (SysTick) as a delay provider.
@@ -72,6 +77,22 @@ impl Delay {
             ms -= 4294967;
         }
         self.delay_us(ms * 1_000);
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl EH1DelayUs for Delay {
+    type Error = Infallible;
+
+    #[inline]
+    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+        Delay::delay_us(self, us);
+        Ok(())
+    }
+
+    fn delay_ms(&mut self, us: u32) -> Result<(), Self::Error> {
+        Delay::delay_ms(self, us);
+        Ok(())
     }
 }
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,3 +1,5 @@
+// # Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+
 //! A delay driver based on SysTick.
 
 use crate::peripheral::{syst::SystClkSource, SYST};


### PR DESCRIPTION
Support for embedded_hal 1.0.0-alpha.8 in addition to 0.2.4.
Delay implementation was aligned for alpha HAL release.