### PR TITLE
Add implementation for critical-section 1.0, for cortex-m v0.7.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,19 @@ jobs:
       matrix:
         # All generated code should be running on stable now
         rust: [stable]
+        features: ["", "critical-section-single-core"]
 
         include:
           # Test MSRV
           - rust: 1.38.0
+            features: ""
 
           # Test nightly but don't fail
           - rust: nightly
+            features: ""
+            experimental: true
+          - rust: nightly
+            features: "critical-section-single-core"
             experimental: true
     steps:
       - uses: actions/checkout@v2
@@ -29,6 +35,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: Run tests
-        run: cargo test --all
+        run: cargo test --all --features "${{ matrix.features }}"
 
 # FIXME: test on macOS and Windows

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -23,3 +23,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          args: --features critical-section-single-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added `critical-section-single-core` feature which provides an implementation for the `critical_section` crate for single-core systems, based on disabling all interrupts. (#448)
+
 ## [v0.7.5] - 2022-05-15
 
 ### Deprecated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ links = "cortex-m"  # prevent multiple versions of this crate to be linked toget
 
 [dependencies]
 bare-metal = { version = "0.2.4", features = ["const-fn"] }
+critical-section = { version = "1.0.0", optional = true }
 volatile-register = "0.2.0"
 bitfield = "0.13.2"
 embedded-hal = "0.2.4"
@@ -32,6 +33,7 @@ cm7-r0p1 = ["cm7"]
 inline-asm = []
 linker-plugin-lto = []
 std = []
+critical-section-single-core = ["critical-section/restore-state-bool"]
 
 [workspace]
 members = ["xtask", "cortex-m-semihosting", "panic-semihosting", "panic-itm"]

--- a/src/critical_section.rs
+++ b/src/critical_section.rs
@@ -1,0 +1,25 @@
+#[cfg(all(cortex_m, feature = "critical-section-single-core"))]
+mod single_core_critical_section {
+    use critical_section::{set_impl, Impl, RawRestoreState};
+
+    use crate::interrupt;
+    use crate::register::primask;
+
+    struct SingleCoreCriticalSection;
+    set_impl!(SingleCoreCriticalSection);
+
+    unsafe impl Impl for SingleCoreCriticalSection {
+        unsafe fn acquire() -> RawRestoreState {
+            let was_active = primask::read().is_active();
+            interrupt::disable();
+            was_active
+        }
+
+        unsafe fn release(was_active: RawRestoreState) {
+            // Only re-enable interrupts if they were enabled before the critical section.
+            if was_active {
+                interrupt::enable()
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ mod macros;
 pub mod asm;
 #[cfg(armv8m)]
 pub mod cmse;
+mod critical_section;
 pub mod delay;
 pub mod interrupt;
 #[cfg(all(not(armv6m), not(armv8m_base)))]


### PR DESCRIPTION
This is a subset of #447 without any breaking changes, just adding the `critical-section` implementation.

The goal is to release it in 0.7.6 so `critical-section` becomes usable without having to wait for cortex-m 0.8.


TODO before merging:

- [x] Wait for `critical-section 1.0` release https://github.com/rust-embedded/critical-section/pull/19