### PR TITLE
Add zero-init-ram feature

### DIFF
--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.7.3]
-
 - Fixed a potential miscompilation caused by the initial stack pointer
   not being 8-byte aligned. This issue affected 0.7.1 and 0.7.2; for
   more details please see [the advisory] ([#467]).
 - A linker error is generated if the initial stack pointer is not 8-byte aligned ([#464]).
 - The initial stack pointer is now forced to be 8-byte aligned in the linker script,
   to defend against it being overridden outside of the cortex-m-rt linker script ([#465]).
+- Add `zero-init-ram` feature to initialize RAM with zeros on startup. This can be necessary on
+  safety-critical hardware to properly initialize memory integrity measures.
 
 [the advisory]: https://github.com/rust-embedded/cortex-m/discussions/469
 [#464]: https://github.com/rust-embedded/cortex-m/issues/464

--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add `zero-init-ram` feature to initialize RAM with zeros on startup. This can be necessary on
+  safety-critical hardware to properly initialize memory integrity measures.
+
+## [v0.7.3]
+
 - Fixed a potential miscompilation caused by the initial stack pointer
   not being 8-byte aligned. This issue affected 0.7.1 and 0.7.2; for
   more details please see [the advisory] ([#467]).
 - A linker error is generated if the initial stack pointer is not 8-byte aligned ([#464]).
 - The initial stack pointer is now forced to be 8-byte aligned in the linker script,
   to defend against it being overridden outside of the cortex-m-rt linker script ([#465]).
-- Add `zero-init-ram` feature to initialize RAM with zeros on startup. This can be necessary on
-  safety-critical hardware to properly initialize memory integrity measures.
 
 [the advisory]: https://github.com/rust-embedded/cortex-m/discussions/469
 [#464]: https://github.com/rust-embedded/cortex-m/issues/464

--- a/cortex-m-rt/Cargo.toml
+++ b/cortex-m-rt/Cargo.toml
@@ -45,6 +45,7 @@ required-features = ["device"]
 device = []
 set-sp = []
 set-vtor = []
+zero-init-ram = []
 
 [package.metadata.docs.rs]
 features = ["device"]

--- a/cortex-m-rt/ci/script.sh
+++ b/cortex-m-rt/ci/script.sh
@@ -63,6 +63,8 @@ main() {
 
             cargo rustc --target "$TARGET" --example minimal --features "set-sp,${needed_features}" -- $linker
             cargo rustc --target "$TARGET" --example minimal --features "set-sp,${needed_features}" --release -- $linker
+            cargo rustc --target "$TARGET" --example minimal --features "zero-init-ram,${needed_features}" -- $linker
+            cargo rustc --target "$TARGET" --example minimal --features "zero-init-ram,${needed_features}" --release -- $linker
             cargo rustc --target "$TARGET" --example minimal --features "set-vtor,${needed_features}" -- $linker
             cargo rustc --target "$TARGET" --example minimal --features "set-vtor,${needed_features}" --release -- $linker
         done

--- a/cortex-m-rt/link.x.in
+++ b/cortex-m-rt/link.x.in
@@ -60,7 +60,9 @@ PROVIDE(__pre_init = DefaultPreInit);
 /* # Sections */
 SECTIONS
 {
-  PROVIDE(_stack_start = ORIGIN(RAM) + LENGTH(RAM));
+  PROVIDE(_ram_start = ORIGIN(RAM) + LENGTH(RAM));
+  PROVIDE(_ram_end = ORIGIN(RAM));
+  PROVIDE(_stack_start = _ram_start);
 
   /* ## Sections in FLASH */
   /* ### Vector table */

--- a/cortex-m-rt/link.x.in
+++ b/cortex-m-rt/link.x.in
@@ -60,9 +60,9 @@ PROVIDE(__pre_init = DefaultPreInit);
 /* # Sections */
 SECTIONS
 {
-  PROVIDE(_ram_start = ORIGIN(RAM) + LENGTH(RAM));
-  PROVIDE(_ram_end = ORIGIN(RAM));
-  PROVIDE(_stack_start = _ram_start);
+  PROVIDE(_ram_start = ORIGIN(RAM));
+  PROVIDE(_ram_end = ORIGIN(RAM) + LENGTH(RAM));
+  PROVIDE(_stack_start = _ram_end);
 
   /* ## Sections in FLASH */
   /* ### Vector table */

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -550,6 +550,7 @@ cfg_global_asm! {
     "bl __pre_init",
 
     // Initialise .bss memory. `__sbss` and `__ebss` come from the linker script.
+    #[cfg(not(feature = "zero-init-ram"))]
     "ldr r0, =__sbss
      ldr r1, =__ebss
      movs r2, #0

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -521,19 +521,6 @@ cfg_global_asm! {
     "ldr r0, =_stack_start
      msr msp, r0",
 
-    // If enabled, initialize RAM with zeros. This is not usually required, but might be necessary
-    // to properly initialize checksum-based memory integrity measures on safety-critical hardware.
-    #[cfg(feature = "zero-init-ram")]
-    "ldr r0, =_ram_start
-     ldr r1, =_ram_end
-     movs r2, #0
-     0:
-     cmp r1, r0
-     beq 1f
-     stm r0!, {{r2}}
-     b 0b
-     1:",
-
     // If enabled, initialise VTOR to the start of the vector table. This is normally initialised
     // by a bootloader when the non-reset value is required, but some bootloaders do not set it,
     // leading to frustrating issues where everything seems to work but interrupts are never
@@ -548,6 +535,19 @@ cfg_global_asm! {
     // potentially time-consuming memory initialisation takes place.
     // Example use cases include disabling default watchdogs or enabling RAM.
     "bl __pre_init",
+
+    // If enabled, initialize RAM with zeros. This is not usually required, but might be necessary
+    // to properly initialize checksum-based memory integrity measures on safety-critical hardware.
+    #[cfg(feature = "zero-init-ram")]
+    "ldr r0, =_ram_start
+     ldr r1, =_ram_end
+     movs r2, #0
+     0:
+     cmp r1, r0
+     beq 1f
+     stm r0!, {{r2}}
+     b 0b
+     1:",
 
     // Initialise .bss memory. `__sbss` and `__ebss` come from the linker script.
     #[cfg(not(feature = "zero-init-ram"))]

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -169,6 +169,13 @@
 //! `_stack_start` value from the linker script. This is not usually required, but some debuggers
 //! do not initialise SP when performing a soft reset, which can lead to stack corruption.
 //!
+//! ## `zero-init-ram`
+//!
+//! If this feature is enabled, RAM is initialized with zeros during startup from the `_ram_start`
+//! value to the `_ram_end` value from the linker script. This is not usually required, but might be
+//! necessary to properly initialize checksum-based memory integrity measures on safety-critical
+//! hardware.
+//!
 //! ## `set-vtor`
 //!
 //! If this feature is enabled, the vector table offset register (VTOR) is initialised in the reset

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -521,8 +521,8 @@ cfg_global_asm! {
     "ldr r0, =_stack_start
      msr msp, r0",
 
-    // If enabled, initialize RAM with zeros. This is normally not necessary but might be required
-    // on custom hardware.
+    // If enabled, initialize RAM with zeros. This is not usually required, but might be necessary
+    // to properly initialize checksum-based memory integrity measures on safety-critical hardware.
     #[cfg(feature = "zero-init-ram")]
     "ldr r0, =_ram_start
      ldr r1, =_ram_end

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -517,8 +517,8 @@ cfg_global_asm! {
     // If enabled, initialize RAM with zeros. This is normally not necessary but might be required
     // on custom hardware.
     #[cfg(feature = "zero-init-ram")]
-    "ldr r0, =_ram_end
-     ldr r1, =_ram_start
+    "ldr r0, =_ram_start
+     ldr r1, =_ram_end
      movs r2, #0
      0:
      cmp r1, r0


### PR DESCRIPTION
Add the 'zero-init-ram' feature that initializes the RAM with zeros during startup. This is normally
not necessary but might be required on custom hardware. If this step is skipped on such hardware,
reading from memory that was never written to will cause a hard-fault.