### PR TITLE
enable GitHub Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # this is the only `Cargo.toml` which isn't part of the workspace
+  - package-ecosystem: "cargo"
+    directory: "/cortex-m-rt/macros/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
this ensures that the dependencies are kept up to date. see [the docs][] for further information.

note that `cortex-m-rt/macros` isn't listed in the main `workspace` and also not in `cortex-m-rt`. thus it has been added here explicitly.

[the docs]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates