### PR TITLE
cortex-m v0.7.7: add documentation for critical-section-single-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.7.7] - 2023-01-03
+
+- Add missing documentation for `critical-section-single-core` feature added
+  in v0.7.6.
+
 ## [v0.7.6] - 2022-08-12
 
 - Added `critical-section-single-core` feature which provides an implementation for the `critical-section` crate for single-core systems, based on disabling all interrupts. (#448)
@@ -750,7 +755,8 @@ fn main() {
 - Functions to get the vector table
 - Wrappers over miscellaneous instructions like `bkpt`
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.6...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.7...HEAD
+[v0.7.7]: https://github.com/rust-embedded/cortex-m/compare/v0.7.6...v0.7.7
 [v0.7.6]: https://github.com/rust-embedded/cortex-m/compare/v0.7.5...v0.7.6
 [v0.7.5]: https://github.com/rust-embedded/cortex-m/compare/v0.7.4...v0.7.5
 [v0.7.4]: https://github.com/rust-embedded/cortex-m/compare/v0.7.3...v0.7.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2018"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,16 @@
 //! The disadvantage is that `inline-asm` requires a Rust version at least 1.59 to use the `asm!()`
 //! macro. In the future 0.8 and above versions of `cortex-m`, this feature will always be enabled.
 //!
+//! ## `critical-section-single-core`
+//!
+//! This feature enables a [`critical-section`](https://github.com/rust-embedded/critical-section)
+//! implementation suitable for single-core targets, based on disabling interrupts globally.
+//!
+//! It is **unsound** to enable it on multi-core targets or for code running in unprivileged mode,
+//! and may cause functional problems in systems where some interrupts must be not be disabled
+//! or critical sections are managed as part of an RTOS. In these cases, you should use
+//! a target-specific implementation instead, typically provided by a HAL or RTOS crate.
+//!
 //! ## `cm7-r0p1`
 //!
 //! This feature enables workarounds for errata found on Cortex-M7 chips with revision r0p1. Some


### PR DESCRIPTION
This got missed in #448; this PR copies the documentation added in #451 to the v0.7.x branch.