### PR TITLE
panic-itm: update crate config so docs aren't empty

### DIFF
--- a/panic-itm/src/lib.rs
+++ b/panic-itm/src/lib.rs
@@ -28,7 +28,7 @@
 //! panicked at 'FOO', src/main.rs:6:5
 //! ```
 
-#![cfg(all(target_arch = "arm", target_os = "none"))]
+#![cfg(any(all(target_arch = "arm", target_os = "none"), doc))]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![no_std]


### PR DESCRIPTION
The docs are currently empty since the module is disabled https://docs.rs/panic-itm/0.4.2/panic_itm/index.html