### PR TITLE
cortex-m-rt: ensure the stack is 8-byte aligned.

### DIFF
--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -573,10 +573,11 @@ cfg_global_asm! {
      isb",
 
     // Push `lr` to the stack for debuggers, to prevent them unwinding past Reset.
+    // Push a dummy `r4` (which is always 0xFFFF_FFFF) to ensure the stack stays 8-byte aligned.
     // See https://sourceware.org/binutils/docs/as/CFI-directives.html.
     ".cfi_def_cfa sp, 0
-     push {{lr}}
-     .cfi_offset lr, 0",
+     push {{r4, lr}}
+     .cfi_offset lr, 4",
 
     // Jump to user main function.
     // `bl` is used for the extended range, but the user main function should not return,

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -574,7 +574,8 @@ cfg_global_asm! {
 
     // Push `lr` to the stack for debuggers, to prevent them unwinding past Reset.
     // Push a dummy `r4` (which is always 0xFFFF_FFFF) to ensure the stack stays 8-byte aligned.
-    // See https://sourceware.org/binutils/docs/as/CFI-directives.html.
+    // For CFI information, see https://sourceware.org/binutils/docs/as/CFI-directives.html.
+    // For 8 byte alignment, see https://github.com/ARM-software/abi-aa/blob/edd7460d87493fff124b8b5713acf71ffc06ee91/aapcs32/aapcs32.rst#6212stack-constraints-at-a-public-interface.
     ".cfi_def_cfa sp, 0
      push {{r4, lr}}
      .cfi_offset lr, 4",


### PR DESCRIPTION
Stack must be 8-byte aligned on ARM. Pushing 1 word makes it not aligned, so we push 2 words.

I'm not sure on the `cfi` changes, so I'd appreciate some double-check.


---

This was breaking code ~~that used LDRD/STRD on stack, since~~ that needs 8-byte alignment, For example:

```rust
#[inline(never)]
pub fn foo(x: bool) -> (u32, [u32; 2]) {
    let array = [3, 99];
    let result = array[x as usize];
    (result, array)
}

hprintln!("false -> {:?}", foo(false));
hprintln!("true -> {:?}", foo(true));
```

compiled to code that ~~does a `strd` on stack~~ does some weird address math with `orr` instead of `add` which is only correct if the stack is 8-byte aligned:

```asm
                             undefined foo()
             undefined         r0:1           <RETURN>
             undefined4        Stack[-0x8]:4  local_8                         
        00000448 82 b0           sub                sp,#0x8
        0000044a 6a 46           mov                r2,sp
        0000044c 4f f0 63 0c     mov.w              r12,#0x63
        00000450 03 23           movs               r3,#0x3
        00000452 42 ea 81 01     orr.w              r1,r2,r1, lsl #0x2
        00000456 cd e9 00 3c     strd               r3,r12,[sp,#0x0]=>local_8
        0000045a 09 68           ldr                r1,[r1,#0x0]
        0000045c 80 e8 0a 10     stm                r0,{r1,r3,r12}
        00000460 02 b0           add                sp,#0x8
        00000462 70 47           bx                 lr
```

which prints

```
false -> (3, [3, 99])
true -> (3, [3, 99])
```

With the fix in this PR, the result is correct:

```
false -> (3, [3, 99])
true -> (99, [3, 99])
```