### PR TITLE
Enforce 8-byte initial stack pointer alignment

### DIFF
--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- A linker error is generated if the initial stack pointer is not 8-byte aligned
+- The initial stack pointer is now forced to be 8-byte aligned in the linker script,
+  to defend against it being overridden outside of the cortex-m-rt linker script
+
 ## [v0.7.2]
 
 - MSRV is now Rust 1.59.

--- a/cortex-m-rt/link.x.in
+++ b/cortex-m-rt/link.x.in
@@ -68,8 +68,12 @@ SECTIONS
   {
     __vector_table = .;
 
-    /* Initial Stack Pointer (SP) value */
-    LONG(_stack_start);
+    /* Initial Stack Pointer (SP) value.
+     * We mask the bottom three bits to force 8-byte alignment.
+     * Despite having an assert for this later, it's possible that a separate
+     * linker script could override _stack_start after the assert is checked.
+     */
+    LONG(_stack_start & 0xFFFFFFF8);
 
     /* Reset vector */
     KEEP(*(.vector_table.reset_vector)); /* this is the `__RESET_VECTOR` symbol */

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -56,8 +56,13 @@
 //!
 //! This optional symbol can be used to indicate where the call stack of the program should be
 //! placed. If this symbol is not used then the stack will be placed at the *end* of the `RAM`
-//! region -- the stack grows downwards towards smaller address. This symbol can be used to place
-//! the stack in a different memory region, for example:
+//! region -- the stack grows downwards towards smaller address.
+//!
+//! For Cortex-M, the `_stack_start` must always be aligned to 8 bytes, which is enforced by
+//! the linker script. If you override it, ensure that whatever value you set is a multiple
+//! of 8 bytes.
+//!
+//! This symbol can be used to place the stack in a different memory region, for example:
 //!
 //! ```text
 //! /* Linker script for the STM32F303VCT6 */


### PR DESCRIPTION
After #463 we discovered that adding a second linker script via another compiler flag could be used to override `_stack_start` without triggering the assert in the main linker script. By masking the value, we force alignment even when the assert doesn't otherwise trigger.