### PR TITLE
nvic: do not require `&mut self` for `request`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking changes
+
+- `NVIC::request()` no longer requires `&mut self`.
+
 ### Added
 - Updated `SCB.ICSR.VECTACTIVE`/`SCB::vect_active()` to be 9 bits instead of 8.
   Also fixes `VectActive::from` to take a `u16` and subtract `16` for

--- a/src/peripheral/nvic.rs
+++ b/src/peripheral/nvic.rs
@@ -94,15 +94,14 @@ impl NVIC {
     /// [`NVIC::pend`]: #method.pend
     #[cfg(not(armv6m))]
     #[inline]
-    pub fn request<I>(&mut self, interrupt: I)
+    pub fn request<I>(interrupt: I)
     where
         I: InterruptNumber,
     {
         let nr = interrupt.number();
 
-        unsafe {
-            self.stir.write(u32::from(nr));
-        }
+        // NOTE(ptr) this is a write to a stateless register
+        unsafe { (*Self::PTR).stir.write(u32::from(nr)) }
     }
 
     /// Disables `interrupt`


### PR DESCRIPTION
It's not needed, the register write is stateless/atomic. 