### PR TITLE
Hardfault trampoline is now optional

### DIFF
--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `zero-init-ram` feature to initialize RAM with zeros on startup. This can be necessary on
   safety-critical hardware to properly initialize memory integrity measures.
 - Add `hardfault-trampoline` feature that is enabled by default which enables
-  the previously required hardfault trampiline. Now when this feature is not active, there will be
+  the previously required hardfault trampoline. Now when this feature is not active, there will be
   no trampoline and the function you write is the exact function that is used as hardfault handler.
 
 ## [v0.7.3]

--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add `zero-init-ram` feature to initialize RAM with zeros on startup. This can be necessary on
   safety-critical hardware to properly initialize memory integrity measures.
+- Add `hardfault-trampoline` feature that is enabled by default which enables
+  the previously required hardfault trampiline. Now when this feature is not active, there will be
+  no trampoline and the function you write is the exact function that is used as hardfault handler.
 
 ## [v0.7.3]
 

--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add `zero-init-ram` feature to initialize RAM with zeros on startup. This can be necessary on
   safety-critical hardware to properly initialize memory integrity measures.
-- Add `hardfault-trampoline` feature that is enabled by default which enables
-  the previously required hardfault trampoline. Now when this feature is not active, there will be
-  no trampoline and the function you write is the exact function that is used as hardfault handler.
+- Add optional `exception` argument for `HardFault`. It has one option `trampoline` which is true by default. When set to false, no trampoline will be created and the function will be called as the exception handler directly.
 
 ## [v0.7.3]
 

--- a/cortex-m-rt/Cargo.toml
+++ b/cortex-m-rt/Cargo.toml
@@ -42,10 +42,12 @@ name = "compiletest"
 required-features = ["device"]
 
 [features]
+default = ["hardfault-trampoline"]
 device = []
 set-sp = []
 set-vtor = []
 zero-init-ram = []
+hardfault-trampoline = ["cortex-m-rt-macros/hardfault-trampoline"]
 
 [package.metadata.docs.rs]
 features = ["device"]

--- a/cortex-m-rt/Cargo.toml
+++ b/cortex-m-rt/Cargo.toml
@@ -42,12 +42,10 @@ name = "compiletest"
 required-features = ["device"]
 
 [features]
-default = ["hardfault-trampoline"]
 device = []
 set-sp = []
 set-vtor = []
 zero-init-ram = []
-hardfault-trampoline = ["cortex-m-rt-macros/hardfault-trampoline"]
 
 [package.metadata.docs.rs]
 features = ["device"]

--- a/cortex-m-rt/macros/Cargo.toml
+++ b/cortex-m-rt/macros/Cargo.toml
@@ -21,6 +21,3 @@ proc-macro2 = "1.0"
 [dependencies.syn]
 features = ["extra-traits", "full"]
 version = "2.0"
-
-[features]
-hardfault-trampoline = []

--- a/cortex-m-rt/macros/Cargo.toml
+++ b/cortex-m-rt/macros/Cargo.toml
@@ -21,3 +21,6 @@ proc-macro2 = "1.0"
 [dependencies.syn]
 features = ["extra-traits", "full"]
 version = "2.0"
+
+[features]
+hardfault-trampoline = []

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -356,8 +356,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             }
 
             f.sig.ident = Ident::new(&format!("__cortex_m_rt_{}", f.sig.ident), Span::call_site());
-            let tramp_ident =
-                Ident::new(&format!("{}_trampoline", f.sig.ident), Span::call_site());
+            let tramp_ident = Ident::new(&format!("{}_trampoline", f.sig.ident), Span::call_site());
 
             if args.trampoline {
                 let ident = &f.sig.ident;

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -10,8 +10,11 @@ use quote::quote;
 use std::collections::HashSet;
 use std::iter;
 use syn::{
-    parse, parse_macro_input, spanned::Spanned, AttrStyle, Attribute, FnArg, Ident, Item, ItemFn,
-    ItemStatic, ReturnType, Stmt, Type, Visibility,
+    parse::{self, Parse},
+    parse_macro_input,
+    spanned::Spanned,
+    AttrStyle, Attribute, FnArg, Ident, Item, ItemFn, ItemStatic, ReturnType, Stmt, Type,
+    Visibility,
 };
 
 #[proc_macro_attribute]
@@ -113,20 +116,72 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
 #[derive(Debug, PartialEq)]
 enum Exception {
     DefaultHandler,
-    HardFault,
+    HardFault(HardFaultArgs),
     NonMaskableInt,
     Other,
+}
+
+#[derive(Debug, PartialEq)]
+struct HardFaultArgs {
+    trampoline: bool,
+}
+
+impl Default for HardFaultArgs {
+    fn default() -> Self {
+        Self { trampoline: true }
+    }
+}
+
+impl Parse for HardFaultArgs {
+    fn parse(input: parse::ParseStream) -> syn::Result<Self> {
+        let mut items = Vec::new();
+        // Read a list of `ident = value,`
+        loop {
+            if input.is_empty() {
+                break;
+            }
+
+            let name = input.parse::<Ident>()?;
+            input.parse::<syn::Token!(=)>()?;
+            let value = input.parse::<syn::Lit>()?;
+
+            items.push((name, value));
+
+            if input.is_empty() {
+                break;
+            }
+
+            input.parse::<syn::Token!(,)>()?;
+        }
+
+        let mut args = Self::default();
+
+        for (name, value) in items {
+            match name.to_string().as_str() {
+                "trampoline" => match value {
+                    syn::Lit::Bool(val) => {
+                        args.trampoline = val.value();
+                    }
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            value,
+                            "Not a valid value. `trampoline` takes a boolean literal",
+                        ))
+                    }
+                },
+                _ => {
+                    return Err(syn::Error::new_spanned(name, "Not a valid argument name"));
+                }
+            }
+        }
+
+        Ok(args)
+    }
 }
 
 #[proc_macro_attribute]
 pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut f = parse_macro_input!(input as ItemFn);
-
-    if !args.is_empty() {
-        return parse::Error::new(Span::call_site(), "This attribute accepts no arguments")
-            .to_compile_error()
-            .into();
-    }
 
     if let Err(error) = check_attr_whitelist(&f.attrs, WhiteListCaller::Exception) {
         return error;
@@ -137,14 +192,34 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let ident_s = ident.to_string();
     let exn = match &*ident_s {
-        "DefaultHandler" => Exception::DefaultHandler,
-        "HardFault" => Exception::HardFault,
-        "NonMaskableInt" => Exception::NonMaskableInt,
+        "DefaultHandler" => {
+            if !args.is_empty() {
+                return parse::Error::new(Span::call_site(), "This attribute accepts no arguments")
+                    .to_compile_error()
+                    .into();
+            }
+            Exception::DefaultHandler
+        }
+        "HardFault" => Exception::HardFault(parse_macro_input!(args)),
+        "NonMaskableInt" => {
+            if !args.is_empty() {
+                return parse::Error::new(Span::call_site(), "This attribute accepts no arguments")
+                    .to_compile_error()
+                    .into();
+            }
+            Exception::NonMaskableInt
+        }
         // NOTE that at this point we don't check if the exception is available on the target (e.g.
         // MemoryManagement is not available on Cortex-M0)
         "MemoryManagement" | "BusFault" | "UsageFault" | "SecureFault" | "SVCall"
         | "DebugMonitor" | "PendSV" | "SysTick" => Exception::Other,
         _ => {
+            if !args.is_empty() {
+                return parse::Error::new(Span::call_site(), "This attribute accepts no arguments")
+                    .to_compile_error()
+                    .into();
+            }
+
             return parse::Error::new(ident.span(), "This is not a valid exception name")
                 .to_compile_error()
                 .into();
@@ -153,7 +228,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
 
     if f.sig.unsafety.is_none() {
         match exn {
-            Exception::DefaultHandler | Exception::HardFault | Exception::NonMaskableInt => {
+            Exception::DefaultHandler | Exception::HardFault(_) | Exception::NonMaskableInt => {
                 // These are unsafe to define.
                 let name = if exn == Exception::DefaultHandler {
                     "`DefaultHandler`".to_string()
@@ -232,74 +307,41 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                 #f
             )
         }
-        Exception::HardFault if cfg!(feature = "hardfault-trampoline") => {
+        Exception::HardFault(args) => {
             let valid_signature = f.sig.constness.is_none()
                 && f.vis == Visibility::Inherited
                 && f.sig.abi.is_none()
-                && f.sig.inputs.len() == 1
-                && match &f.sig.inputs[0] {
-                    FnArg::Typed(arg) => match arg.ty.as_ref() {
-                        Type::Reference(r) => r.lifetime.is_none() && r.mutability.is_none(),
+                && if args.trampoline {
+                    match &f.sig.inputs[0] {
+                        FnArg::Typed(arg) => match arg.ty.as_ref() {
+                            Type::Reference(r) => {
+                                r.lifetime.is_none()
+                                    && r.mutability.is_none()
+                                    && f.sig.inputs.len() == 1
+                            }
+                            _ => false,
+                        },
                         _ => false,
+                    }
+                } else {
+                    f.sig.inputs.is_empty()
+                }
+                && f.sig.generics.params.is_empty()
+                && f.sig.generics.where_clause.is_none()
+                && f.sig.variadic.is_none()
+                && match f.sig.output {
+                    ReturnType::Default => false,
+                    ReturnType::Type(_, ref ty) => matches!(**ty, Type::Never(_)),
+                };
+
+            if !valid_signature {
+                return parse::Error::new(
+                    fspan,
+                    if args.trampoline {
+                        "`HardFault` handler must have signature `unsafe fn(&ExceptionFrame) -> !`"
+                    } else {
+                        "`HardFault` handler must have signature `unsafe fn() -> !`"
                     },
-                    _ => false,
-                }
-                && f.sig.generics.params.is_empty()
-                && f.sig.generics.where_clause.is_none()
-                && f.sig.variadic.is_none()
-                && match f.sig.output {
-                    ReturnType::Default => false,
-                    ReturnType::Type(_, ref ty) => matches!(**ty, Type::Never(_)),
-                };
-
-            if !valid_signature {
-                return parse::Error::new(
-                    fspan,
-                    "`HardFault` handler must have signature `unsafe fn(&ExceptionFrame) -> !`",
-                )
-                .to_compile_error()
-                .into();
-            }
-
-            f.sig.ident = Ident::new(&format!("__cortex_m_rt_{}", f.sig.ident), Span::call_site());
-            let tramp_ident = Ident::new(&format!("{}_trampoline", f.sig.ident), Span::call_site());
-            let ident = &f.sig.ident;
-
-            let (ref cfgs, ref attrs) = extract_cfgs(f.attrs.clone());
-
-            quote!(
-                #(#cfgs)*
-                #(#attrs)*
-                #[doc(hidden)]
-                #[export_name = "HardFault"]
-                // Only emit link_section when building for embedded targets,
-                // because some hosted platforms (used to check the build)
-                // cannot handle the long link section names.
-                #[cfg_attr(target_os = "none", link_section = ".HardFault.user")]
-                pub unsafe extern "C" fn #tramp_ident(frame: &::cortex_m_rt::ExceptionFrame) {
-                    #ident(frame)
-                }
-
-                #f
-            )
-        }
-        Exception::HardFault => {
-            let valid_signature = f.sig.constness.is_none()
-                && f.vis == Visibility::Inherited
-                && f.sig.abi.is_none()
-                && f.sig.inputs.is_empty()
-                && f.sig.generics.params.is_empty()
-                && f.sig.generics.where_clause.is_none()
-                && f.sig.variadic.is_none()
-                && match f.sig.output {
-                    ReturnType::Default => false,
-                    ReturnType::Type(_, ref ty) => matches!(**ty, Type::Never(_)),
-                };
-
-            if !valid_signature {
-                return parse::Error::new(
-                    fspan,
-                    "`HardFault` handler must have signature `unsafe fn() -> !`",
                 )
                 .to_compile_error()
                 .into();
@@ -307,14 +349,62 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
 
             f.sig.ident = Ident::new(&format!("__cortex_m_rt_{}", f.sig.ident), Span::call_site());
 
-            quote!(
-                #[export_name = "HardFault"]
-                // Only emit link_section when building for embedded targets,
-                // because some hosted platforms (used to check the build)
-                // cannot handle the long link section names.
-                #[cfg_attr(target_os = "none", link_section = ".HardFault.user")]
-                #f
-            )
+            if args.trampoline {
+                let tramp_ident =
+                    Ident::new(&format!("{}_trampoline", f.sig.ident), Span::call_site());
+                let ident = &f.sig.ident;
+
+                let (ref cfgs, ref attrs) = extract_cfgs(f.attrs.clone());
+
+                quote!(
+                    #(#cfgs)*
+                    #(#attrs)*
+                    #[doc(hidden)]
+                    #[export_name = "HardFault"]
+                    // Only emit link_section when building for embedded targets,
+                    // because some hosted platforms (used to check the build)
+                    // cannot handle the long link section names.
+                    #[cfg_attr(target_os = "none", link_section = ".HardFault.user")]
+                    pub unsafe extern "C" fn #tramp_ident(frame: &::cortex_m_rt::ExceptionFrame) {
+                        #ident(frame)
+                    }
+
+                    #f
+
+                    // HardFault exceptions are bounced through this trampoline which grabs the stack pointer at
+                    // the time of the exception and passes it to the user's HardFault handler in r0.
+                    // Depending on the stack mode in EXC_RETURN, fetches stack from either MSP or PSP.
+                    core::arch::global_asm!(
+                        ".cfi_sections .debug_frame
+                        .section .HardFaultTrampoline, \"ax\"
+                        .global HardFaultTrampline
+                        .type HardFaultTrampline,%function
+                        .thumb_func
+                        .cfi_startproc
+                        HardFaultTrampoline:",
+                                        "mov r0, lr
+                        movs r1, #4
+                        tst r0, r1
+                        bne 0f
+                        mrs r0, MSP
+                        b HardFault
+                        0:
+                        mrs r0, PSP
+                        b HardFault",
+                        ".cfi_endproc
+                        .size HardFaultTrampoline, . - HardFaultTrampoline",
+                    );
+                )
+            } else {
+                quote!(
+                    #[export_name = "HardFault"]
+                    // Only emit link_section when building for embedded targets,
+                    // because some hosted platforms (used to check the build)
+                    // cannot handle the long link section names.
+                    #[cfg_attr(target_os = "none", link_section = ".HardFault.user")]
+                    #f
+                )
+            }
         }
         Exception::NonMaskableInt | Exception::Other => {
             let valid_signature = f.sig.constness.is_none()

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -368,11 +368,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                     #(#cfgs)*
                     #(#attrs)*
                     #[doc(hidden)]
-                    #[export_name = "HardFault"]
-                    // Only emit link_section when building for embedded targets,
-                    // because some hosted platforms (used to check the build)
-                    // cannot handle the long link section names.
-                    #[cfg_attr(target_os = "none", link_section = ".HardFault.user")]
+                    #[export_name = "HardFaultUser"]
                     pub unsafe extern "C" fn #tramp_ident(frame: &::cortex_m_rt::ExceptionFrame) {
                         #ident(frame)
                     }
@@ -384,23 +380,23 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                     // Depending on the stack mode in EXC_RETURN, fetches stack from either MSP or PSP.
                     core::arch::global_asm!(
                         ".cfi_sections .debug_frame
-                        .section .HardFaultTrampoline, \"ax\"
-                        .global HardFaultTrampline
-                        .type HardFaultTrampline,%function
+                        .section .HardFault.user, \"ax\"
+                        .global HardFault
+                        .type HardFault,%function
                         .thumb_func
                         .cfi_startproc
-                        HardFaultTrampoline:",
-                                        "mov r0, lr
-                        movs r1, #4
-                        tst r0, r1
-                        bne 0f
-                        mrs r0, MSP
-                        b HardFault
+                        HardFault:",
+                           "mov r0, lr
+                            movs r1, #4
+                            tst r0, r1
+                            bne 0f
+                            mrs r0, MSP
+                            b HardFaultUser
                         0:
-                        mrs r0, PSP
-                        b HardFault",
+                            mrs r0, PSP
+                            b HardFaultUser",
                         ".cfi_endproc
-                        .size HardFaultTrampoline, . - HardFaultTrampoline",
+                        .size HardFault, . - HardFault",
                     );
                 )
             } else {

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -287,7 +287,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             let valid_signature = f.sig.constness.is_none()
                 && f.vis == Visibility::Inherited
                 && f.sig.abi.is_none()
-                && f.sig.inputs.len() == 0
+                && f.sig.inputs.is_empty()
                 && f.sig.generics.params.is_empty()
                 && f.sig.generics.where_clause.is_none()
                 && f.sig.variadic.is_none()
@@ -667,7 +667,7 @@ fn check_attr_whitelist(attrs: &[Attribute], caller: WhiteListCaller) -> Result<
             }
         };
 
-        return Err(parse::Error::new(attr.span(), &err_str)
+        return Err(parse::Error::new(attr.span(), err_str)
             .to_compile_error()
             .into());
     }

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -225,12 +225,15 @@
 //! - `DefaultHandler`. This is the default handler. If not overridden using `#[exception] fn
 //! DefaultHandler(..` this will be an infinite loop.
 //!
-//! - `HardFaultTrampoline`. This is the real hard fault handler. This function is simply a
-//! trampoline that jumps into the user defined hard fault handler named `HardFault`. The
-//! trampoline is required to set up the pointer to the stacked exception frame.
-//!
-//! - `HardFault`. This is the user defined hard fault handler. If not overridden using
-//! `#[exception] fn HardFault(..` it will default to an infinite loop.
+//! - `HardFault` and `_HardFault`. These function handle the hard fault handling and what they
+//! do depends on whether the hard fault is overridden and whether the trampoline is enabled (which it is by default).
+//!   - No override: Both are the same function. The function is an infinite loop defined in the cortex-m-rt crate.
+//!   - Trampoline enabled: `HardFault` is the real hard fault handler defined in assembly. This function is simply a
+//! trampoline that jumps into the rust defined `_HardFault` function. This second function jumps to the user-defined
+//! handler with the exception frame as parameter. This second jump is usually optimised away with inlining.
+//!   - Trampoline disabled: `HardFault` is the user defined function. This means the user function is called directly
+//! from the vector table. `_HardFault` still exists, but is an empty function that is purely there for compiler
+//! diagnostics.
 //!
 //! - `__STACK_START`. This is the first entry in the `.vector_table` section. This symbol contains
 //! the initial value of the stack pointer; this is where the stack will be located -- the stack
@@ -724,15 +727,26 @@ pub use macros::entry;
 ///
 /// # Usage
 ///
-/// `#[exception] unsafe fn HardFault(..` sets the hard fault handler. The handler must have
-/// signature `unsafe fn(&ExceptionFrame) -> !`. This handler is not allowed to return as that can
-/// cause undefined behavior.
+/// ## HardFault handler
+///
+/// `#[exception(trampoline = true)] unsafe fn HardFault(..` sets the hard fault handler.
+/// If the trampoline parameter is set to true, the handler must have signature `unsafe fn(&ExceptionFrame) -> !`.
+/// If set to false, the handler must have signature `unsafe fn() -> !`.
+///
+/// This handler is not allowed to return as that can cause undefined behavior.
+///
+/// To maintain backwards compatibility the attribute can be used without trampoline parameter (`#[exception]`),
+/// which sets the trampoline to true.
+///
+/// ## Default handler
 ///
 /// `#[exception] unsafe fn DefaultHandler(..` sets the *default* handler. All exceptions which have
 /// not been assigned a handler will be serviced by this handler. This handler must have signature
 /// `unsafe fn(irqn: i16) [-> !]`. `irqn` is the IRQ number (See CMSIS); `irqn` will be a negative
 /// number when the handler is servicing a core exception; `irqn` will be a positive number when the
 /// handler is servicing a device specific exception (interrupt).
+///
+/// ## Other handlers
 ///
 /// `#[exception] fn Name(..` overrides the default handler for the exception with the given `Name`.
 /// These handlers must have signature `[unsafe] fn() [-> !]`. When overriding these other exception

--- a/cortex-m-rt/tests/README.md
+++ b/cortex-m-rt/tests/README.md
@@ -1,0 +1,7 @@
+# How to run
+
+To run the compile tests, use the following command on the root of the project:
+
+```
+cargo test --package cortex-m-rt --test compiletest --features device
+```

--- a/cortex-m-rt/tests/compile-fail/hard-fault-bad-signature-2.rs
+++ b/cortex-m-rt/tests/compile-fail/hard-fault-bad-signature-2.rs
@@ -1,0 +1,18 @@
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt;
+extern crate panic_halt;
+
+use cortex_m_rt::{entry, exception, ExceptionFrame};
+
+#[entry]
+fn foo() -> ! {
+    loop {}
+}
+
+#[exception(trampoline = true)]
+unsafe fn HardFault() -> ! {
+    //~^ ERROR `HardFault` handler must have signature `unsafe fn(&ExceptionFrame) -> !`
+    loop {}
+}

--- a/cortex-m-rt/tests/compile-fail/hard-fault-bad-signature-3.rs
+++ b/cortex-m-rt/tests/compile-fail/hard-fault-bad-signature-3.rs
@@ -1,0 +1,18 @@
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt;
+extern crate panic_halt;
+
+use cortex_m_rt::{entry, exception, ExceptionFrame};
+
+#[entry]
+fn foo() -> ! {
+    loop {}
+}
+
+#[exception(trampoline = false)]
+unsafe fn HardFault(_ef: &ExceptionFrame) -> ! {
+    //~^ ERROR `HardFault` handler must have signature `unsafe fn() -> !`
+    loop {}
+}

--- a/cortex-m-rt/tests/compile-fail/hard-fault-twice-mixed-trampoline.rs
+++ b/cortex-m-rt/tests/compile-fail/hard-fault-twice-mixed-trampoline.rs
@@ -11,8 +11,8 @@ fn foo() -> ! {
     loop {}
 }
 
-#[exception]
-unsafe fn HardFault(_ef: &ExceptionFrame) -> ! {
+#[exception(trampoline = false)]
+unsafe fn HardFault() -> ! {
     loop {}
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-embedded/cortex-m/issues/406

This was less work than I thought! (So please check if I didn't miss anything haha)

Basically, anything that works with the hardfault trampoline is cfg'ed behind the new feature flag.
I've opted to make the flag default to avoid breaking changes... (unless somebody has `default-features = false` in their Cargo.toml). So technically it's still a breaking change I think?

Also, we probably want to have a test for this all. There seems to be a test for the trampoline version.
But I don't really know how testing in this repo is set up.