### PR TITLE
CI: actions-rs/toolchain -> dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,9 @@ jobs:
             experimental: true
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: Run tests
         run: cargo test --all --exclude cortex-m-rt --exclude testsuite --features cortex-m/critical-section-single-core
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,11 +16,8 @@ jobs:
           ref: refs/pull/${{ github.event.number }}/head
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,11 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
         run: cargo test --all --exclude cortex-m-rt --exclude testsuite
       - uses: imjohnbo/issue-bot@v3
@@ -37,11 +33,7 @@ jobs:
         working-directory: cortex-m-rt
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install all Rust targets for stable
         run: rustup target install --toolchain=stable thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf thumbv8m.base-none-eabi thumbv8m.main-none-eabi thumbv8m.main-none-eabihf
       - name: Install qemu and gcc

--- a/.github/workflows/on-target.yml
+++ b/.github/workflows/on-target.yml
@@ -15,12 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: thumbv7m-none-eabi
+          targets: thumbv7m-none-eabi
       - name: Build testsuite
         env:
           RUSTFLAGS: -C link-arg=-Tlink.x -D warnings
@@ -40,12 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: thumbv6m-none-eabi
+          targets: thumbv6m-none-eabi
       - name: Modify linkerfile
         run: |
           sed -i 's/FLASH : ORIGIN = 0x00000000, LENGTH = 256K/FLASH : ORIGIN = 0x8000000, LENGTH = 128K/g' memory.x

--- a/.github/workflows/rt-ci.yml
+++ b/.github/workflows/rt-ci.yml
@@ -24,11 +24,9 @@ jobs:
         working-directory: cortex-m-rt
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: Install all Rust targets for ${{ matrix.rust }}
         run: rustup target install --toolchain=${{ matrix.rust }} thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf thumbv8m.base-none-eabi thumbv8m.main-none-eabi thumbv8m.main-none-eabihf
       - name: Install qemu and gcc
@@ -63,11 +61,7 @@ jobs:
         working-directory: cortex-m-rt
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install all Rust targets
         run: rustup target install thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf thumbv8m.base-none-eabi thumbv8m.main-none-eabi thumbv8m.main-none-eabihf
       - name: Build examples for thumbv6m-none-eabi

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -13,11 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
`actions-rs` is deprecated as of 2023-10-13, and was not maintained long before that.  This replaces all uses of [`actions-rs/toolchain`](https://github.com/actions-rs/toolchain) with [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain).

We still have a use of `actions-rs/clippy-check`.  For most repositories I simply run the CLI version, the UI isn't as nice, but it is easier to maintain.  I can make this change too, if desired.
