### PR TITLE
semihosting: silence clippy::result_unit_err in hio

### DIFF
--- a/cortex-m-semihosting/src/hio.rs
+++ b/cortex-m-semihosting/src/hio.rs
@@ -1,5 +1,8 @@
 //! Host I/O
 
+// Fixing this lint requires a breaking change that does not add much value
+#![allow(clippy::result_unit_err)]
+
 use crate::nr;
 use core::{fmt, slice};
 


### PR DESCRIPTION
Fixing this lint requires a breaking change that does not add much value in my opinion.

Alternatively I can make the breaking change to fix this:

* `hstdout` and `hstderr` return `Option<HostStream>` instead of `Result<HostStream, ()>`
* `write_all`
  * Option 1: Returns `bool` with `#[must_use = "Return bool is true if an error occurred"]`
  * Option 2: Add a `pub struct Error(());` type and return `Result<(), Error>`
  