### PR TITLE
CI: remove node16 dependency for self-hosted runner

### DIFF
--- a/.github/workflows/on-target.yml
+++ b/.github/workflows/on-target.yml
@@ -72,7 +72,9 @@ jobs:
         run: probe-run --version
       - name: List probes
         run: probe-run --list-probes
-      - uses: actions/download-artifact@v3
+      # TODO: replace with actions/download-artifact when they update to node20
+      # https://github.com/actions/download-artifact/issues/230
+      - uses: newAM/download-artifact@4202241ccada6f83f838525a8af979a4ec900a49
         with:
           name: testsuite-bin
           path: testsuite-bin


### PR DESCRIPTION
node16 has been EOL for months and has been removed from the OS I used to host the runner.

`actions/checkout` has updated to node20, but `actions/download-artifact` has not (see https://github.com/actions/download-artifact/issues/230).

This points the `download-artifact` action to my fork that uses node20.

