### PR TITLE
Fix nightly CI failures

### DIFF
--- a/.github/workflows/rt-ci.yml
+++ b/.github/workflows/rt-ci.yml
@@ -64,6 +64,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install all Rust targets
         run: rustup target install thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf thumbv8m.base-none-eabi thumbv8m.main-none-eabi thumbv8m.main-none-eabihf
+      - name: Remove examples that pass by failing
+        run: rm examples/data_overflow.rs
       - name: Build examples for thumbv6m-none-eabi
         run: cargo build --target=thumbv6m-none-eabi --features cortex-m/critical-section-single-core --examples
       - name: Build examples for thumbv7m-none-eabi

--- a/cortex-m-rt/examples/alignment.rs
+++ b/cortex-m-rt/examples/alignment.rs
@@ -21,12 +21,12 @@ static RODATA2: &[u8; 2] = b"34";
 #[entry]
 fn main() -> ! {
     unsafe {
-        let _bss1 = ptr::read_volatile(&BSS1);
-        let _bss2 = ptr::read_volatile(&BSS2);
-        let _data1 = ptr::read_volatile(&DATA1);
-        let _data2 = ptr::read_volatile(&DATA2);
-        let _rodata1 = ptr::read_volatile(&RODATA1);
-        let _rodata2 = ptr::read_volatile(&RODATA2);
+        let _bss1 = ptr::read_volatile(ptr::addr_of!(BSS1));
+        let _bss2 = ptr::read_volatile(ptr::addr_of!(BSS2));
+        let _data1 = ptr::read_volatile(ptr::addr_of!(DATA1));
+        let _data2 = ptr::read_volatile(ptr::addr_of!(DATA2));
+        let _rodata1 = ptr::read_volatile(ptr::addr_of!(RODATA1));
+        let _rodata2 = ptr::read_volatile(ptr::addr_of!(RODATA2));
     }
 
     loop {}

--- a/cortex-m-rt/examples/data_overflow.rs
+++ b/cortex-m-rt/examples/data_overflow.rs
@@ -22,8 +22,8 @@ static mut DATA: [u8; 16 * 1024] = [1u8; 16 * 1024];
 #[entry]
 fn main() -> ! {
     unsafe {
-        let _bigdata = ptr::read_volatile(&RODATA as *const u8);
-        let _bigdata = ptr::read_volatile(&DATA as *const u8);
+        let _bigdata = ptr::read_volatile(ptr::addr_of!(RODATA));
+        let _bigdata = ptr::read_volatile(ptr::addr_of!(DATA));
     }
 
     loop {}

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -1038,7 +1038,7 @@ pub fn heap_start() -> *mut u32 {
         static mut __sheap: u32;
     }
 
-    unsafe { &mut __sheap }
+    unsafe { core::ptr::addr_of_mut!(__sheap) }
 }
 
 // Entry point is Reset.

--- a/panic-itm/src/lib.rs
+++ b/panic-itm/src/lib.rs
@@ -43,6 +43,7 @@ use cortex_m::iprintln;
 use cortex_m::peripheral::ITM;
 
 #[panic_handler]
+#[cfg(all(not(test), not(doctest)))]
 fn panic(info: &PanicInfo) -> ! {
     interrupt::disable();
 


### PR DESCRIPTION
The `data_overflow` test seems to have been malfunctioning, and changing to `addr_of!` fixes it, but for some reason this test takes 10's of minutes to compile in CI?  I'm not sure what to make of this.