### PR TITLE
cmrt: change condition on _stext location check

### DIFF
--- a/cortex-m-rt/link.x.in
+++ b/cortex-m-rt/link.x.in
@@ -257,9 +257,9 @@ ASSERT(ADDR(.vector_table) + SIZEOF(.vector_table) <= _stext, "
 ERROR(cortex-m-rt): The .text section can't be placed inside the .vector_table section
 Set _stext to an address greater than the end of .vector_table (See output of `nm`)");
 
-ASSERT(_stext + SIZEOF(.text) < ORIGIN(FLASH) + LENGTH(FLASH), "
+ASSERT(_stext > ORIGIN(FLASH) && _stext < ORIGIN(FLASH) + LENGTH(FLASH), "
 ERROR(cortex-m-rt): The .text section must be placed inside the FLASH memory.
-Set _stext to an address smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)'");
+Set _stext to an address within the FLASH region.");
 
 /* # Other checks */
 ASSERT(SIZEOF(.got) == 0, "


### PR DESCRIPTION
This avoids spurious errors when `.text` doesn't fit in `FLASH` which have nothing to do with the position of `_stext`. By not checking, we let the linker provide its own, more-useful, error.

Closes #509.