### PR TITLE
HardFaultTrampoline now passes &mut ExceptionFrame

### DIFF
--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -325,7 +325,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                         && match &f.sig.inputs[0] {
                             FnArg::Typed(arg) => match arg.ty.as_ref() {
                                 Type::Reference(r) => {
-                                    r.lifetime.is_none() && r.mutability.is_none()
+                                    r.lifetime.is_none() && r.mutability.is_some()
                                 }
                                 _ => false,
                             },
@@ -346,7 +346,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                 return parse::Error::new(
                     fspan,
                     if args.trampoline {
-                        "`HardFault` handler must have signature `unsafe fn(&ExceptionFrame) -> !`"
+                        "`HardFault` handler must have signature `unsafe fn(&mut ExceptionFrame) -> !`"
                     } else {
                         "`HardFault` handler must have signature `unsafe fn() -> !`"
                     },
@@ -368,7 +368,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                     #(#attrs)*
                     #[doc(hidden)]
                     #[export_name = "_HardFault"]
-                    unsafe extern "C" fn #tramp_ident(frame: &::cortex_m_rt::ExceptionFrame) {
+                    unsafe extern "C" fn #tramp_ident(frame: &mut ::cortex_m_rt::ExceptionFrame) {
                         #ident(frame)
                     }
 


### PR DESCRIPTION
In order to allow for a user provided HardFault handler to modify the exception frame (e.g. to return to a different PC) the signature for the function to be used with the `#[HardFault]` handler now has a `&mut ExceptionFrame` instead of just a reference.

Use case: we want to catch an exception, so we set some flag, run some code that might trigger a HardFault, update the flag in the handler, and return to the instruction _after_ the one that caused the exception. We can then check the flag to see if an exception occurred or not. Key point is: to return to the instruction following the one that caused the exception, we want to modify the PC on the `ExceptionFrame` before loading EXC_RETURN onto the PC.