### PR TITLE
Update critical_section.rs

### DIFF
--- a/cortex-m/src/critical_section.rs
+++ b/cortex-m/src/critical_section.rs
@@ -9,6 +9,7 @@ set_impl!(SingleCoreCriticalSection);
 unsafe impl Impl for SingleCoreCriticalSection {
     unsafe fn acquire() -> RawRestoreState {
         let was_active = primask::read().is_active();
+        // NOTE: Fence guarantees are provided by interrupt::disable(), which performs a `compiler_fence(SeqCst)`.
         interrupt::disable();
         was_active
     }
@@ -16,6 +17,8 @@ unsafe impl Impl for SingleCoreCriticalSection {
     unsafe fn release(was_active: RawRestoreState) {
         // Only re-enable interrupts if they were enabled before the critical section.
         if was_active {
+            // NOTE: Fence guarantees are provided by interrupt::disable(), which performs a
+            // `compiler_fence(SeqCst)`.
             interrupt::enable()
         }
     }

--- a/cortex-m/src/critical_section.rs
+++ b/cortex-m/src/critical_section.rs
@@ -17,7 +17,7 @@ unsafe impl Impl for SingleCoreCriticalSection {
     unsafe fn release(was_active: RawRestoreState) {
         // Only re-enable interrupts if they were enabled before the critical section.
         if was_active {
-            // NOTE: Fence guarantees are provided by interrupt::disable(), which performs a
+            // NOTE: Fence guarantees are provided by interrupt::enable(), which performs a
             // `compiler_fence(SeqCst)`.
             interrupt::enable()
         }


### PR DESCRIPTION
Critical section docs require acquire/release to have similar fencing guarantees.

I was confused when I didn't see them, and didn't realize they were implicitly provided by the interrupt methods.

Adding docs to help the next person.