### PR TITLE
Use correct cfg for `cm7` feature

### DIFF
--- a/cortex-m/src/peripheral/mod.rs
+++ b/cortex-m/src/peripheral/mod.rs
@@ -60,7 +60,7 @@
 use core::marker::PhantomData;
 use core::ops;
 
-#[cfg(cm7)]
+#[cfg(feature = "cm7")]
 pub mod ac;
 #[cfg(not(armv6m))]
 pub mod cbp;
@@ -94,7 +94,7 @@ mod test;
 #[allow(clippy::manual_non_exhaustive)]
 pub struct Peripherals {
     /// Cortex-M7 TCM and cache access control.
-    #[cfg(cm7)]
+    #[cfg(feature = "cm7")]
     pub AC: AC,
 
     /// Cache and branch predictor maintenance operations.
@@ -178,7 +178,7 @@ impl Peripherals {
         TAKEN = true;
 
         Peripherals {
-            #[cfg(cm7)]
+            #[cfg(feature = "cm7")]
             AC: AC {
                 _marker: PhantomData,
             },
@@ -230,15 +230,15 @@ impl Peripherals {
 }
 
 /// Access control
-#[cfg(cm7)]
+#[cfg(feature = "cm7")]
 pub struct AC {
     _marker: PhantomData<*const ()>,
 }
 
-#[cfg(cm7)]
+#[cfg(feature = "cm7")]
 unsafe impl Send for AC {}
 
-#[cfg(cm7)]
+#[cfg(feature = "cm7")]
 impl AC {
     /// Pointer to the register block
     pub const PTR: *const self::ac::RegisterBlock = 0xE000_EF90 as *const _;


### PR DESCRIPTION
Fixes #517.

Change all occurrences of `#[cfg(cm7)]` into `#[cfg(feature = "cm7")]` so the code sections are actually accessible with the `cm7`  feature.