### PR TITLE
Remove nomem flag from isb, dsb and dmb

### DIFF
--- a/asm/inline.rs
+++ b/asm/inline.rs
@@ -72,21 +72,21 @@ pub unsafe fn __delay(cyc: u32) {
 #[inline(always)]
 pub unsafe fn __dmb() {
     compiler_fence(Ordering::SeqCst);
-    asm!("dmb", options(nomem, nostack, preserves_flags));
+    asm!("dmb", options(nostack, preserves_flags));
     compiler_fence(Ordering::SeqCst);
 }
 
 #[inline(always)]
 pub unsafe fn __dsb() {
     compiler_fence(Ordering::SeqCst);
-    asm!("dsb", options(nomem, nostack, preserves_flags));
+    asm!("dsb", options(nostack, preserves_flags));
     compiler_fence(Ordering::SeqCst);
 }
 
 #[inline(always)]
 pub unsafe fn __isb() {
     compiler_fence(Ordering::SeqCst);
-    asm!("isb", options(nomem, nostack, preserves_flags));
+    asm!("isb", options(nostack, preserves_flags));
     compiler_fence(Ordering::SeqCst);
 }
 


### PR DESCRIPTION
Probably not as important on 0.7 as on the main branch: The precompiled functions are not affected, and the inline ones are protected by additional `compiler_fence` calls, so the compiler can't reorder anyway. Still better to conform to the reference and not use `nomem` on assembly blocks that are used for synchronization.

Fixes #502