### PR TITLE
panic-semihosting, panic-itm: Move `#![no_std]` above `#![cfg(target...)]`

### DIFF
--- a/panic-itm/src/lib.rs
+++ b/panic-itm/src/lib.rs
@@ -28,10 +28,10 @@
 //! panicked at 'FOO', src/main.rs:6:5
 //! ```
 
+#![no_std]
 #![cfg(any(all(target_arch = "arm", target_os = "none"), doc))]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![no_std]
 
 extern crate cortex_m;
 

--- a/panic-semihosting/src/lib.rs
+++ b/panic-semihosting/src/lib.rs
@@ -48,10 +48,10 @@
 //! We discourage using this feature when the program will run on hardware as the exit call can
 //! leave the hardware debugger in an inconsistent state.
 
+#![no_std]
 #![cfg(all(target_arch = "arm", target_os = "none"))]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![no_std]
 
 extern crate cortex_m;
 extern crate cortex_m_semihosting as sh;


### PR DESCRIPTION
... so that the crates are [always `no_std`](https://rust.godbolt.org/z/q4eGM19W7), even on unsupported platforms.

For dependent binaries, this will cause either:
1. No change, when compiling for `all(target_arch = "arm", target_os = "none")`.
2. No change, for binaries which aren't `#[no_std]`, already provide a different `#[panic_handler]`, or already pull in `std` via another dependency.
3. New compilation error because `#[panic_handler]` is not defined and is now not pulled in from `std` as it was before.

cc https://github.com/rust-lang/miri/issues/3498#issuecomment-2088590212