### PR TITLE
Expose configuration of the SEVONPEND bit within the System Control Register (SCR)

### DIFF
--- a/cortex-m/src/peripheral/scb.rs
+++ b/cortex-m/src/peripheral/scb.rs
@@ -832,6 +832,26 @@ impl SCB {
     }
 }
 
+const SCB_SCR_SEVONPEND: u32 = 0x1 << 4;
+
+impl SCB {
+    /// Set the SEVONPEND bit in the SCR register
+    #[inline]
+    pub fn set_sevonpend(&mut self) {
+        unsafe {
+            self.scr.modify(|scr| scr | SCB_SCR_SEVONPEND);
+        }
+    }
+
+    /// Clear the SEVONPEND bit in the SCR register
+    #[inline]
+    pub fn clear_sevonpend(&mut self) {
+        unsafe {
+            self.scr.modify(|scr| scr & !SCB_SCR_SEVONPEND);
+        }
+    }
+}
+
 const SCB_AIRCR_VECTKEY: u32 = 0x05FA << 16;
 const SCB_AIRCR_PRIGROUP_MASK: u32 = 0x7 << 8;
 const SCB_AIRCR_SYSRESETREQ: u32 = 1 << 2;


### PR DESCRIPTION
This PR exposes the `SEVONPEND` bit of the System Control Register (`SCR`) within the SCB type. This seems inline with the current implementation of the other two defined `SCR` fields: `SLEEPDEEP` and `SLEEPONEXIT`. 

As a side-note, I'm relatively new to embedded development in rust, so if this has been omitted for some specific reason I'm unaware of, I'm happy to be corrected. :) That being said, I simply implemented these two new methods in the same way that `set/clear_sleepdeep` and `set/clear_sleeponexit` were implemented with the help of section `B3.2.7` of the [ARMv7-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0403/latest/).