### PR TITLE
CI: fix data_overflow test

### DIFF
--- a/cortex-m-rt/ci/script.sh
+++ b/cortex-m-rt/ci/script.sh
@@ -55,8 +55,8 @@ main() {
                 cargo rustc --target "$TARGET" --example "$ex" --features "${needed_features}" --release -- $linker
             done
             for ex in "${fail_examples[@]}"; do
-                ! cargo rustc --target "$TARGET" --example "$ex" --features "${needed_features}" -- $linker
-                ! cargo rustc --target "$TARGET" --example "$ex" --features "${needed_features}" --release -- $linker
+                cargo rustc --target "$TARGET" --example "$ex" --features "${needed_features}" -- $linker && exit 1
+                cargo rustc --target "$TARGET" --example "$ex" --features "${needed_features}" --release -- $linker && exit 1
             done
             cargo rustc --target "$TARGET" --example device --features "device,${needed_features}" -- $linker
             cargo rustc --target "$TARGET" --example device --features "device,${needed_features}" --release -- $linker

--- a/cortex-m-rt/examples/data_overflow.rs
+++ b/cortex-m-rt/examples/data_overflow.rs
@@ -9,21 +9,22 @@ extern crate cortex_m_rt as rt;
 extern crate panic_halt;
 
 use core::ptr;
-
 use rt::entry;
 
 // This large static array uses most of .rodata
-static RODATA: [u8; 48 * 1024] = [1u8; 48 * 1024];
+const RODATA_SIZE: usize = 250 * 1024;
+static RODATA: [u8; RODATA_SIZE] = [1u8; RODATA_SIZE];
 
 // This large mutable array causes .data to use the rest of FLASH
 // without also overflowing RAM.
-static mut DATA: [u8; 16 * 1024] = [1u8; 16 * 1024];
+const DATA_SIZE: usize = 8 * 1024;
+static mut DATA: [u8; DATA_SIZE] = [1u8; DATA_SIZE];
 
 #[entry]
 fn main() -> ! {
     unsafe {
-        let _bigdata = ptr::read_volatile(ptr::addr_of!(RODATA));
-        let _bigdata = ptr::read_volatile(ptr::addr_of!(DATA));
+        let _bigdata: u8 = ptr::read_volatile(ptr::addr_of!(RODATA) as *const u8);
+        let _bigdata: u8 = ptr::read_volatile(ptr::addr_of!(DATA) as *const u8);
     }
 
     loop {}


### PR DESCRIPTION
Long story:

* This test was introduced
* `ci/script.sh` did not correctly check for failures, [SC2251]
  * Thanks #404 for the tip!
* The FLASH size was increased, and the test incorrectly passed, but nobody noticed.
* I modified the test in #505 which made it fail again, but for the wrong reason.  `ptr::read_volatile(ptr::addr_of!(RODATA))` reads the entire array, which is not equivalent to the original code `ptr::read_volatile(&RODATA as *const u8)` which read a single element of the array.
* The test now failed, but the stack related overflow takes rustc a LONG time to compile, and pushed our CI times to >30m.

These changes fix ci/scripts.sh to exit with a non-zero code if data_overflow is passing, and makes data_overflow fail to compile for the original reason, updating RODATA to reflect the increased FLASH size.

[SC2251]: https://www.shellcheck.net/wiki/SC2251