### PR TITLE
panic-itm: set edition to 2018 to fix warning

### DIFF
--- a/panic-itm/Cargo.toml
+++ b/panic-itm/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "panic-itm"
 repository = "https://github.com/rust-embedded/cortex-m"
 version = "0.4.2"
+edition = "2018"
 
 [dependencies]
 cortex-m = { path = "../cortex-m", version = ">= 0.5.8, < 0.8" }


### PR DESCRIPTION
We get this warning: `cortex-m/panic-itm/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021`.

I chose edition 2018 to match the `1.31.0` MSRV of `panic-itm`.