### PR TITLE
Adds a `paint-stack` feature.

### DIFF
--- a/cortex-m-rt/Cargo.toml
+++ b/cortex-m-rt/Cargo.toml
@@ -46,6 +46,7 @@ device = []
 set-sp = []
 set-vtor = []
 zero-init-ram = []
+paint-stack = []
 
 [package.metadata.docs.rs]
 features = ["device"]

--- a/cortex-m-rt/examples/qemu.rs
+++ b/cortex-m-rt/examples/qemu.rs
@@ -1,7 +1,14 @@
 #![no_main]
 #![no_std]
 
-use core::fmt::Write;
+use core::{
+    fmt::Write,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+static DATA_VAL: AtomicU32 = AtomicU32::new(1234);
+
+static BSS_VAL: AtomicU32 = AtomicU32::new(0);
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
@@ -9,7 +16,10 @@ fn main() -> ! {
 
     loop {
         let mut hstdout = cortex_m_semihosting::hio::hstdout().unwrap();
-        write!(hstdout, "x = {}\n", x).unwrap();
+        // check that .data and .bss were initialised OK
+        if DATA_VAL.load(Ordering::Relaxed) == 1234 && BSS_VAL.load(Ordering::Relaxed) == 0 {
+            _ = writeln!(hstdout, "x = {}", x);
+        }
         cortex_m_semihosting::debug::exit(cortex_m_semihosting::debug::EXIT_SUCCESS);
     }
 }

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -188,8 +188,8 @@
 //! ## `paint-stack`
 //!
 //! Everywhere between `__sheap` and `___stack_start` is painted with the fixed value `STACK_PAINT_VALUE`.
-//! You can then inspect memory during debugging to determine how much of the stack has been used
-//! - where the stack has been used the 'paint' will have been 'scrubbed off' and the memory will
+//! You can then inspect memory during debugging to determine how much of the stack has been used -
+//! where the stack has been used the 'paint' will have been 'scrubbed off' and the memory will
 //! have a value other than `STACK_PAINT_VALUE`.
 //!
 //! # Inspection
@@ -232,7 +232,7 @@
 //!   using the `main` symbol so you will also find that symbol in your program.
 //!
 //! - `DefaultHandler`. This is the default handler. If not overridden using `#[exception] fn
-//! DefaultHandler(..` this will be an infinite loop.
+//!   DefaultHandler(..` this will be an infinite loop.
 //!
 //! - `HardFault` and `_HardFault`. These function handle the hard fault handling and what they
 //!   do depends on whether the hard fault is overridden and whether the trampoline is enabled (which it is by default).
@@ -899,6 +899,7 @@ pub static __ONCE__: () = ();
 /// Registers stacked (pushed onto the stack) during an exception.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[allow(dead_code)]
 pub struct ExceptionFrame {
     r0: u32,
     r1: u32,

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -187,7 +187,8 @@
 //!
 //! ## `paint-stack`
 //!
-//! Everywhere between `__sheap` and `___stack_start` is painted with the fixed value `STACK_PAINT_VALUE`.
+//! Everywhere between `__sheap` and `___stack_start` is painted with the fixed value
+//! `STACK_PAINT_VALUE`, which is `0xCCCC_CCCC`.
 //! You can then inspect memory during debugging to determine how much of the stack has been used -
 //! where the stack has been used the 'paint' will have been 'scrubbed off' and the memory will
 //! have a value other than `STACK_PAINT_VALUE`.
@@ -475,9 +476,8 @@
 extern crate cortex_m_rt_macros as macros;
 
 /// The 32-bit value the stack is painted with before the program runs.
-///
-/// Note: keep this value in-sync with the start-up assembly code, as we can't
-/// use const values in `global_asm!` yet.
+// Note: keep this value in-sync with the start-up assembly code, as we can't
+// use const values in `global_asm!` yet.
 #[cfg(feature = "paint-stack")]
 pub const STACK_PAINT_VALUE: u32 = 0xcccc_cccc;
 


### PR DESCRIPTION
Paints the stack with a fixed 0xcccccccc value, which makes it easier to see the stack high-water mark.

Also update the qemu.rs example to verify a .data value and a .bss value.