### PR TITLE
run clippy directly on pull request

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches-ignore:
       - "gh-readonly-queue/**"
-  pull_request_target:
+  pull_request:
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
We don't need to use pull_request_target now we're not using the clippy integration, and it seems to be messing up actually running the clippy check as the PR runs end up cloning master instead of the PR branch.