### PR TITLE
Allow `expect` as attr

### DIFF
--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -744,6 +744,7 @@ fn check_attr_whitelist(attrs: &[Attribute], caller: WhiteListCaller) -> Result<
         "forbid",
         "cold",
         "naked",
+        "expect",
     ];
 
     'o: for attr in attrs {


### PR DESCRIPTION
Since [Rust 1.81](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html) 
you can lint on using `#[expect(lint)]` which is nice to ensure code doesn't allow unnecessary lint violations.

This needs to be added to the whitelist for it to work on items marked with cortex-m-rt proc macros though.