### PR TITLE
Wrap getting a &mut from a static mut in an unsafe block

### DIFF
--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -85,7 +85,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
                 {
                     #(#attrs)*
                     static mut #ident: #ty = #expr;
-                    &mut #ident
+                    unsafe { &mut #ident }
                 }
             }
         })
@@ -486,7 +486,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                         {
                             #(#attrs)*
                             static mut #ident: #ty = #expr;
-                            &mut #ident
+                            unsafe { &mut #ident }
                         }
                     }
                 })
@@ -596,7 +596,7 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
                 {
                     #(#attrs)*
                     static mut #ident: #ty = #expr;
-                    &mut #ident
+                    unsafe { &mut #ident }
                 }
             }
         })


### PR DESCRIPTION
Fixes #537