### PR TITLE
Allow static_mut_refs lint in macro expansions

### DIFF
--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -103,6 +103,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         #[doc(hidden)]
         #[export_name = "main"]
         pub unsafe extern "C" fn #tramp_ident() {
+            #[allow(static_mut_refs)]
             #ident(
                 #(#resource_args),*
             )
@@ -500,6 +501,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[doc(hidden)]
                 #[export_name = #ident_s]
                 pub unsafe extern "C" fn #tramp_ident() {
+                    #[allow(static_mut_refs)]
                     #ident(
                         #(#resource_args),*
                     )
@@ -614,6 +616,7 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
         #[doc(hidden)]
         #[export_name = #ident_s]
         pub unsafe extern "C" fn #tramp_ident() {
+            #[allow(static_mut_refs)]
             #ident(
                 #(#resource_args),*
             )


### PR DESCRIPTION
On ~~nightly~~ beta, the static_mut_refs lint defaults to warn. With some of our examples using `#[deny(warnings)]`, this leads to the following error:

```
error: creating a mutable reference to mutable static is discouraged
  --> cortex-m-rt/examples/entry-static.rs:15:16
   |
15 |     static mut COUNT: u32 = 0;
   |                ^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
```

With edition 2024, the lint will probably default to deny. (https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html)

To avoid that, set #[allow(static_mut_refs)] locally in the macro expansion.

This only silences the warning and doesn't answer the underlying question if we want to do that transform at all. See eg. https://github.com/rust-embedded/cortex-m/issues/411 for discussion.