### PR TITLE
Fix CI after update of ubuntu and rust

### DIFF
--- a/.github/workflows/on-target.yml
+++ b/.github/workflows/on-target.yml
@@ -23,7 +23,7 @@ jobs:
           RUSTFLAGS: -C link-arg=-Tlink.x -D warnings
         run: cargo build -p testsuite --target thumbv7m-none-eabi
       - name: Install QEMU
-        run: sudo apt-get update && sudo apt-get install qemu qemu-system-arm
+        run: sudo apt-get update && sudo apt-get install qemu-system-arm
       - name: Run testsuite
         run: |
           qemu-system-arm \

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -1079,7 +1079,10 @@ pub fn heap_start() -> *mut u32 {
         static mut __sheap: u32;
     }
 
-    unsafe { core::ptr::addr_of_mut!(__sheap) }
+    #[allow(unused_unsafe)] // no longer unsafe since rust 1.82.0
+    unsafe {
+        core::ptr::addr_of_mut!(__sheap)
+    }
 }
 
 // Entry point is Reset.

--- a/cortex-m-semihosting/src/export.rs
+++ b/cortex-m-semihosting/src/export.rs
@@ -1,5 +1,9 @@
 //! IMPLEMENTATION DETAILS USED BY MACROS
 
+// This must be replaced by a different solution before rust edition 2024
+// https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html
+#![allow(static_mut_refs)]
+
 use core::fmt::{self, Write};
 
 use crate::hio::{self, HostStream};

--- a/cortex-m/src/itm.rs
+++ b/cortex-m/src/itm.rs
@@ -57,7 +57,7 @@ unsafe fn write_aligned_impl(port: &mut Stim, buffer: &[u8]) {
 
 struct Port<'p>(&'p mut Stim);
 
-impl<'p> fmt::Write for Port<'p> {
+impl fmt::Write for Port<'_> {
     #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         write_all(self.0, s.as_bytes());


### PR DESCRIPTION
The qemu package is no longer available. Fortunately, it's not really used by the CI script. It uses qemu-system-arm, which is also installed.

(See https://github.com/rust-embedded/cortex-m/actions/runs/11363980750/job/31609061545?pr=560 as an example for a pipeline failing without this fix.)

And nightly introduced some new lints that broke the build due to `--deny warnings`.