### PR TITLE
Fix wording on clear_current

### DIFF
--- a/cortex-m/src/peripheral/syst.rs
+++ b/cortex-m/src/peripheral/syst.rs
@@ -53,7 +53,7 @@ const SYST_CALIB_NOREF: u32 = 1 << 31;
 impl SYST {
     /// Clears current value to 0
     ///
-    /// After calling `clear_current()`, the next call to `has_wrapped()` will return `false`.
+    /// After calling `clear_current()`, the next call to `has_wrapped()`, unless called after the reload time (if the counter is enabled), will return `false`.
     #[inline]
     pub fn clear_current(&mut self) {
         unsafe { self.cvr.write(0) }


### PR DESCRIPTION
The current wording implies the next call to `has_wrapped()` after `clear_current()` always returns false. According to the arm docs this is not always true:
![image](https://github.com/user-attachments/assets/cc42de1d-505f-4889-bf8a-cea854c2ab93)
