### PR TITLE
cortex-m-rt: fix off-by-one in .text in FLASH section assert

### DIFF
--- a/cortex-m-rt/link.x.in
+++ b/cortex-m-rt/link.x.in
@@ -266,7 +266,7 @@ ASSERT(ADDR(.vector_table) + SIZEOF(.vector_table) <= _stext, "
 ERROR(cortex-m-rt): The .text section can't be placed inside the .vector_table section
 Set _stext to an address greater than the end of .vector_table (See output of `nm`)");
 
-ASSERT(_stext > ORIGIN(FLASH) && _stext < ORIGIN(FLASH) + LENGTH(FLASH), "
+ASSERT(_stext >= ORIGIN(FLASH) && _stext < ORIGIN(FLASH) + LENGTH(FLASH), "
 ERROR(cortex-m-rt): The .text section must be placed inside the FLASH memory.
 Set _stext to an address within the FLASH region.");
 


### PR DESCRIPTION
The original assertion states that is checking that .text is inside flash, but it also precludes .text being at the start of flash.

This shouldn't affect anyone using the linker script from within cortex-m-rt as the vector table is always at the start. Only folks using this script as a template for a custom linker script would notice this issue.

Background:
I was using this linker script as a template for writing a run-from-ram binary for rp2040.
The way the rp2040 tools identify a run-from-ram binary is that the entry point is the first thing in the binary.
So I moved the vector table back, and the Entry function to the start, and then hit this assertion.