### PR TITLE
Optimize critical_section: use MSR instruction

### DIFF
--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -33,7 +33,7 @@ cm7 = []
 cm7-r0p1 = ["cm7"]
 linker-plugin-lto = []
 std = []
-critical-section-single-core = ["critical-section/restore-state-bool"]
+critical-section-single-core = ["critical-section/restore-state-u32"]
 
 [package.metadata.docs.rs]
 targets = [

--- a/cortex-m/src/interrupt.rs
+++ b/cortex-m/src/interrupt.rs
@@ -66,18 +66,17 @@ pub fn free<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
-    let primask = crate::register::primask::read();
+    // Backup previous state of PRIMASK register. We access the entire register directly as a
+    // u32 instead of using the primask::read() function to minimize the number of processor
+    // cycles during which interrupts are disabled.
+    let primask = crate::register::primask::read_raw();
 
     // disable interrupts
     disable();
 
     let r = f();
 
-    // If the interrupts were active before our `disable` call, then re-enable
-    // them. Otherwise, keep them disabled
-    if primask.is_active() {
-        unsafe { enable() }
-    }
+    crate::register::primask::write_raw(primask);
 
     r
 }

--- a/cortex-m/src/interrupt.rs
+++ b/cortex-m/src/interrupt.rs
@@ -76,7 +76,9 @@ where
 
     let r = f();
 
-    crate::register::primask::write_raw(primask);
+    unsafe {
+        crate::register::primask::write_raw(primask);
+    }
 
     r
 }

--- a/cortex-m/src/lib.rs
+++ b/cortex-m/src/lib.rs
@@ -19,6 +19,11 @@
 //! or critical sections are managed as part of an RTOS. In these cases, you should use
 //! a target-specific implementation instead, typically provided by a HAL or RTOS crate.
 //!
+//! The critical section has been optimized to block interrupts for as few cycles as possible,
+//! but -- due to `critical-section` implementation details -- incurs branches in a normal build
+//! configuration. For minimal interrupt latency, you can achieve inlining by enabling
+//! [linker-plugin-based LTO](https://doc.rust-lang.org/rustc/linker-plugin-lto.html).
+//!
 //! ## `cm7-r0p1`
 //!
 //! This feature enables workarounds for errata found on Cortex-M7 chips with revision r0p1. Some

--- a/cortex-m/src/register/primask.rs
+++ b/cortex-m/src/register/primask.rs
@@ -53,7 +53,7 @@ pub fn read_raw() -> u32 {
 /// Note that bits [31:1] are reserved and SBZP (Should-Be-Zero-or-Preserved)
 #[cfg(cortex_m)]
 #[inline]
-pub fn write_raw(r: u32) {
+pub unsafe fn write_raw(r: u32) {
     // Ensure no preceeding memory accesses are reordered to after interrupts are possibly enabled.
     compiler_fence(Ordering::SeqCst);
     unsafe { asm!("msr PRIMASK, {}", in(reg) r, options(nomem, nostack, preserves_flags)) };

--- a/cortex-m/src/register/primask.rs
+++ b/cortex-m/src/register/primask.rs
@@ -2,6 +2,7 @@
 
 #[cfg(cortex_m)]
 use core::arch::asm;
+#[cfg(cortex_m)]
 use core::sync::atomic::{compiler_fence, Ordering};
 
 /// All exceptions with configurable priority are ...

--- a/cortex-m/src/register/primask.rs
+++ b/cortex-m/src/register/primask.rs
@@ -51,6 +51,13 @@ pub fn read_raw() -> u32 {
 
 /// Writes the entire PRIMASK register
 /// Note that bits [31:1] are reserved and SBZP (Should-Be-Zero-or-Preserved)
+///
+/// # Safety
+///
+/// This method is unsafe as other unsafe code may rely on interrupts remaining disabled, for
+/// example during a critical section, and being able to safely re-enable them would lead to
+/// undefined behaviour. Do not call this function in a context where interrupts are expected to
+/// remain disabled -- for example, in the midst of a critical section or `interrupt::free()` call.
 #[cfg(cortex_m)]
 #[inline]
 pub unsafe fn write_raw(r: u32) {

--- a/cortex-m/src/register/primask.rs
+++ b/cortex-m/src/register/primask.rs
@@ -2,36 +2,60 @@
 
 #[cfg(cortex_m)]
 use core::arch::asm;
+use core::sync::atomic::{compiler_fence, Ordering};
 
-/// Priority mask register
-pub struct Primask(pub u32);
+/// All exceptions with configurable priority are ...
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Primask {
+    /// Active
+    Active,
+    /// Inactive
+    Inactive,
+}
 
 impl Primask {
     /// All exceptions with configurable priority are active
     #[inline]
     pub fn is_active(self) -> bool {
-        !self.is_inactive()
+        self == Primask::Active
     }
 
     /// All exceptions with configurable priority are inactive
     #[inline]
     pub fn is_inactive(self) -> bool {
-        self.0 & (1 << 0) == (1 << 0)
+        self == Primask::Inactive
     }
 }
 
-/// Reads the CPU register
+/// Reads the prioritizable interrupt mask
 #[cfg(cortex_m)]
 #[inline]
 pub fn read() -> Primask {
-    let r: u32;
-    unsafe { asm!("mrs {}, PRIMASK", out(reg) r, options(nomem, nostack, preserves_flags)) };
-    Primask(r)
+    if read_raw() & (1 << 0) == (1 << 0) {
+        Primask::Inactive
+    } else {
+        Primask::Active
+    }
 }
 
-/// Writes the CPU register
+/// Reads the entire PRIMASK register
+/// Note that bits [31:1] are reserved and UNK (Unknown)
 #[cfg(cortex_m)]
 #[inline]
-pub fn write(r: u32) {
+pub fn read_raw() -> u32 {
+    let r: u32;
+    unsafe { asm!("mrs {}, PRIMASK", out(reg) r, options(nomem, nostack, preserves_flags)) };
+    r
+}
+
+/// Writes the entire PRIMASK register
+/// Note that bits [31:1] are reserved and SBZP (Should-Be-Zero-or-Preserved)
+#[cfg(cortex_m)]
+#[inline]
+pub fn write_raw(r: u32) {
+    // Ensure no preceeding memory accesses are reordered to after interrupts are possibly enabled.
+    compiler_fence(Ordering::SeqCst);
     unsafe { asm!("msr PRIMASK, {}", in(reg) r, options(nomem, nostack, preserves_flags)) };
+    // Ensure no subsequent memory accesses are reordered to before interrupts are possibly disabled.
+    compiler_fence(Ordering::SeqCst);
 }


### PR DESCRIPTION
(Marking as draft because I'm a Rust beginner who's probably doing things all wrong, and because it changes the API).

To avoid branches and unnecessary code in the acquire and release functions, simply write back the original value to the PRIMASK register using the MSR instruction. This reduces the number of cycles that the processor runs with interrupts disabled, improving interrupt latency.

Unfortunately due to how the critical-section dependency is implemented ([`extern "Rust"`](https://github.com/rust-embedded/critical-section/blob/cebd3d76cc5237d77abd0e03c090577fad1c689f/src/lib.rs#L195-L220)), there is still a branch to and return from the acquire and release functions.

Disassembly with `--release`:
<details>
<summary>Before - thumbv6m-none-eabi</summary>

```
<_critical_section_1_0_acquire>:
               	movs	r0, #0x1
               	mrs	r1, primask
               	ands	r1, r0
               	rsbs	r0, r1, #0
               	adcs	r0, r1
               	cpsid i
               	bx	lr

<_critical_section_1_0_release>:
               	cmp	r0, #0x0
               	beq	0x80002d6 <_critical_section_1_0_release+0x6> @ imm = #0x0
               	cpsie i
               	bx	lr
```
</details>

<details>
<summary>Before - thumbv7m-none-eabi</summary>

```
<_critical_section_1_0_acquire>:
               	mrs	r0, primask
               	movs	r1, #0x1
               	cpsid i
               	bic.w	r0, r1, r0
               	bx	lr

<_critical_section_1_0_release>:
               	cmp	r0, #0x0
               	it	eq
               	bxeq	lr
               	cpsie i
               	bx	lr
```
</details>

With this PR, the generated code is the same on thumbv6m and thumbv7m:
```
<_critical_section_1_0_acquire>:
               	mrs	r0, primask
               	cpsid i
               	bx	lr

<_critical_section_1_0_release>:
               	msr	primask, r0
               	bx	lr
```

This changes the critical-section dependency to use `u32` as the `RawRestoreState` type instead of `bool`.

The `register::primask` module now defines a `struct(pub u32)` instead of an `enum`, and additionally a `write` function for use with the critical section. This is a breaking change to the API if you were using the enum values instead of the `is_(in)active` functions.

Is there a better way to achieve this without changing the API?