### PR TITLE
Fix stack end placement

### DIFF
--- a/cortex-m-rt/link.x.in
+++ b/cortex-m-rt/link.x.in
@@ -182,11 +182,12 @@ SECTIONS
     __euninit = .;
   } > RAM
 
-  /* Place the heap right after `.uninit` in RAM */
-  PROVIDE(__sheap = __euninit);
+  /* Align `__sheap` and `_stack_end` pointers to 4 bytes */
+  . = ALIGN(4);
 
-  /* Place stack end at the end of allocated RAM */
-  PROVIDE(_stack_end = __euninit);
+  /* Place the heap start and stack end at the end of allocated RAM */
+  PROVIDE(__sheap = .);
+  PROVIDE(_stack_end = .);
 
   /* ## .got */
   /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in


### PR DESCRIPTION
The stack end / heap start is placed just after `.uninit` section. It is fine until a custom section is placed just after the `.uninit` section. If application places a custom section just after the `.uninit` section, there is a collision of the custom section and heap start / stack end.

There is still a solution since both `__sheap` and `_stack_end` are designed to be overrided by an application, but changing their placement in the proposed way can save some debugging time. Proposed fix does not change behavior if no custom section added.