### PR TITLE
Fix asm::delay() variability due to alignment

### DIFF
--- a/cortex-m/src/asm.rs
+++ b/cortex-m/src/asm.rs
@@ -33,6 +33,10 @@ pub fn delay(cycles: u32) {
     let real_cycles = 1 + cycles / 2;
     unsafe {
         asm!(
+            // The `bne` on some cores (eg Cortex-M4) will take a different number of instructions
+            // depending on the alignment of the branch target.  Set the alignment of the top of the
+            // loop to prevent surprising timing changes when the alignment of the delay() changes.
+            ".p2align 3",
             // Use local labels to avoid R_ARM_THM_JUMP8 relocations which fail on thumbv6m.
             "1:",
             "subs {}, #1",


### PR DESCRIPTION
While testing a new clocking API in [atsamd-rs](https://github.com/atsamd-rs/atsamd), we encountered a very strange behaviour which took some time to track down - seemingly innocuous changes (eg, enabling features that weren't used by the firmware, or adding a debug call) would result in wildly different execution speed of a test program.  In the context of testing at a new clocking API, at least two of us assumed the issue was down to the clock speed changing, but in fact it was the number of cycles of delay we were getting for calls to `asm::delay()`.  This turns out to be a result of the Cortex-M4 taking a variable number of cycles to execute a conditional branch, based on the alignment of the target.

Although the method is strictly conforming to the documentation by delaying /at least/ N cycles, the sensitivity to alignment is quite surprising.  This PR aligns the loop target, to remove this surprising behaviour.

Resolves part of https://github.com/rust-embedded/cortex-m/issues/151