### PR TITLE
Latest rust has changed its error output

### DIFF
--- a/cortex-m-rt/tests/compile-fail/interrupt-not-reexported.rs
+++ b/cortex-m-rt/tests/compile-fail/interrupt-not-reexported.rs
@@ -11,5 +11,5 @@ fn foo() -> ! {
     loop {}
 }
 
-#[interrupt] //~ ERROR failed to resolve: use of undeclared crate or module `interrupt`
+#[interrupt] //~ ERROR failed to resolve: use of unresolved module or unlinked crate `interrupt`
 fn USART1() {}


### PR DESCRIPTION
The latest version of Rust produces different error messages and so our canary test fails.

See https://github.com/rust-embedded/cortex-m/actions/runs/14417822062/job/40436630371 for an example failure.

This PR merely updates the expected output to match what the compiler does.