### PR TITLE
Fix __pre_init example

### DIFF
--- a/cortex-m-rt/examples/pre_init.rs
+++ b/cortex-m-rt/examples/pre_init.rs
@@ -13,6 +13,9 @@ use rt::entry;
 // For example, it can be used to disable the watchdog.
 core::arch::global_asm! {
     r#"
+.global __pre_init
+.type __pre_init,%function
+.thumb_func
 __pre_init:
     // Do what you need to do before RAM is initialized.
     bx lr


### PR DESCRIPTION
Without specifying the `.global` attribute, the default `__pre_init` was not overridden.