### PR TITLE
`cortex-m-rt`: Fix build command in docs

### DIFF
--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -153,11 +153,24 @@
 //! }
 //! EOF
 //!
-//! $ cargo rustc --target thumbv7m-none-eabi -- -C link-arg=-nostartfiles -C link-arg=-Tlink.x
-//!
+//! $ RUSTFLAGS="-C link-arg=-Tlink.x" cargo build --target thumbv7m-none-eabi
 //! $ file target/thumbv7m-none-eabi/debug/app
 //! app: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, (..)
 //! ```
+//!
+//! To avoid typing the long command, you can create a `.cargo/config.toml` file:
+//!
+//! ```toml
+//! [target.thumbv7m-none-eabi]
+//! rustflags = ["-C", "link-arg=-Tlink.x"]
+//!
+//! [build]
+//! target = "thumbv7m-none-eabi"
+//! ```
+//!
+//! With this configuration, a simple `cargo build` is enough.
+//!
+//! For Cortex-M4 devices, use the target thumbv7em-none-eabi instead.
 //!
 //! # Optional features
 //!


### PR DESCRIPTION
The docs say to pass the `-nostartfiles` flag to the linker. This is a leftover from when GCC was used as the linker. This pull request fixes the build command so that it works with the default `rust-ldd` linker.

While at it, add a sample .cargo/config.toml file.

Fixes #610