### PR TITLE
Add skip-data-init feature to disable .data section initialization

### DIFF
--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Mark `pre_init` as deprecated
 - Add `set_msplim` feature to conditionally set the MSPLIM register at device
   reset ([#580]).
+- Add `skip-data-init` feature to optionally skip copying the `.data` section.
 
 ## [v0.7.5]
 

--- a/cortex-m-rt/Cargo.toml
+++ b/cortex-m-rt/Cargo.toml
@@ -48,6 +48,7 @@ set-vtor = []
 set-msplim = []
 zero-init-ram = []
 paint-stack = []
+skip-data-init = []
 
 [package.metadata.docs.rs]
 features = ["device"]

--- a/cortex-m-rt/examples/skip-data-init.rs
+++ b/cortex-m-rt/examples/skip-data-init.rs
@@ -1,0 +1,38 @@
+//! Example demonstrating the skip-data-init feature
+//! 
+//! This feature is useful when using bootloaders (like RP2040's boot2) that:
+//! 1. Copy all data from Flash to RAM
+//! 2. Unmap the Flash from memory space
+//! 3. Jump to the Reset handler
+//!
+//! In such scenarios, the default cortex-m-rt data initialization would fail
+//! because it tries to copy from Flash which is no longer accessible.
+//!
+//! To use this feature, enable it in your Cargo.toml:
+//! ```toml
+//! [dependencies]
+//! cortex-m-rt = { version = "0.7", features = ["skip-data-init"] }
+//! ```
+//!
+//! And ensure your bootloader or linker script properly initializes .data before
+//! jumping to Reset.
+
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+use cortex_m_rt::entry;
+
+static mut COUNTER: u32 = 42;
+
+#[entry]
+fn main() -> ! {
+    unsafe {
+        COUNTER += 1;
+    }
+    
+    loop {
+        cortex_m::asm::nop();
+    }
+}

--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -513,6 +513,11 @@
 #![deny(missing_docs)]
 #![no_std]
 
+#[cfg(all(feature = "skip-data-init", feature = "zero-init-ram"))]
+compile_error!(
+    "features `skip-data-init` and `zero-init-ram` cannot be enabled at the same time"
+);
+
 extern crate cortex_m_rt_macros as macros;
 
 /// The 32-bit value the stack is painted with before the program runs.


### PR DESCRIPTION
## This PR adds an optional feature to skip .data initialization during startup.

## Introduces:
- the skip-data-init feature that disables the .data copy loop in the reset handler, for boot flows that already initialize RAM (e.g. RP2040 boot2 that copies to RAM and unmaps flash).

- Adds a compile-time guard preventing skip-data-init from being used with zero-init-ram.

- Includes a minimal example at [skip-data-init.rs](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- Default behavior is unchanged; .data is still copied when the feature is not enabled.

### This PR tried to address issue #609 