### PR TITLE
Update remaining crates to edition 2021.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,17 @@ jobs:
       matrix:
         # All generated code should be running on stable now
         rust: [stable]
+        test_cortex_m_types: [true]
 
         include:
           # Test MSRV
-          - rust: 1.61.0
+          - rust: 1.71.0
+            # Should be set to true for >= 1.81.0
+            test_cortex_m_types: false
 
           # Test nightly but don't fail
           - rust: nightly
+            test_cortex_m_types: true
             experimental: true
     steps:
       - uses: actions/checkout@v4
@@ -27,8 +31,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Run tests
-        if: ${{ matrix.rust != '1.61.0' }}
+        if: ${{ matrix.test_cortex_m_types }}
         run: cargo test --all --exclude cortex-m-rt --exclude testsuite --features cortex-m/critical-section-single-core
-      - name: Run tests for 1.61.0 (need to exclude cortex-m-types)
-        if: ${{ matrix.rust == '1.61.0' }}
+      - name: Run tests for < 1.81.0 (need to exclude cortex-m-types)
+        if: ${{ matrix.test_cortex_m_types == false }}
         run: cargo test --all --exclude cortex-m-rt --exclude testsuite --exclude cortex-m-types --features cortex-m/critical-section-single-core

--- a/.github/workflows/rt-ci.yml
+++ b/.github/workflows/rt-ci.yml
@@ -11,7 +11,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
-        rust: [nightly, stable, 1.61.0]
+        rust: [nightly, stable, 1.71.0]
 
         include:
           # Nightly is only for reference and allowed to fail

--- a/cortex-m-rt/CHANGELOG.md
+++ b/cortex-m-rt/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   from an external device. Note that this relies on the bootloader to have already
   copied `.data` to the VMA before relinquishing control.
 - Updated references from 'Cortex-M Team' to 'Arm Team'
+- Bump MSRV to 1.71
 
 ## [v0.7.5]
 

--- a/cortex-m-rt/Cargo.toml
+++ b/cortex-m-rt/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.7.5"
 autoexamples = true
 links = "cortex-m-rt" # Prevent multiple versions of cortex-m-rt being linked
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.71"
 
 [dependencies]
 cortex-m-rt-macros = { path = "macros", version = "=0.7.5" }

--- a/cortex-m-rt/macros/Cargo.toml
+++ b/cortex-m-rt/macros/Cargo.toml
@@ -9,7 +9,7 @@ name = "cortex-m-rt-macros"
 repository = "https://github.com/rust-embedded/cortex-m"
 version = "0.7.5"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.71"
 
 [lib]
 proc-macro = true

--- a/cortex-m-semihosting/Cargo.toml
+++ b/cortex-m-semihosting/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
 version = "0.5.0"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.71"
 
 [features]
 jlink-quirks = []

--- a/cortex-m/CHANGELOG.md
+++ b/cortex-m/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- MSRV is 1.61 to match cortex-m-rt crate
+- MSRV is 1.71 to match cortex-m-rt crate
 - Add `enter_unprivileged` function to switch to unprivileged mode (on the Process Stack, or `PSP`)
 - Updated references from 'Cortex-M Team' to 'Arm Team'
 

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -11,10 +11,10 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
+edition = "2021"
 version = "0.7.7"
-edition = "2018"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
-rust-version = "1.61"
+rust-version = "1.71"
 
 [dependencies]
 bare-metal = { version = "0.2.4", features = ["const-fn"] }

--- a/panic-itm/Cargo.toml
+++ b/panic-itm/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["panic-impl", "panic-handler", "ITM", "ARM", "Cortex-M"]
 license = "MIT OR Apache-2.0"
 name = "panic-itm"
 repository = "https://github.com/rust-embedded/cortex-m"
+edition = "2021"
 version = "0.4.2"
-edition = "2018"
 
 [dependencies]
 cortex-m = { path = "../cortex-m", version = ">= 0.5.8, < 0.8" }

--- a/panic-semihosting/Cargo.toml
+++ b/panic-semihosting/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "panic-semihosting"
 repository = "https://github.com/rust-embedded/cortex-m"
 version = "0.6.0"
-rust-version = "1.61"
+rust-version = "1.71"
 edition = "2021"
 
 [dependencies]

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The Embedded Devices Working Group's Arm Team<cortex-m@teams.rust-embedded.org>"]
 name = "testsuite"
 publish = false
-edition = "2018"
+edition = "2021"
 version = "0.1.0"
 
 [features]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.0.0"
 authors = ["The Embedded Devices Working Group's Arm Team<cortex-m@teams.rust-embedded.org>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[test]]


### PR DESCRIPTION
This pushes the crates that are still listed as edition 2018 to 2021. I test built all of them.

@jonathanpallant adds:

I think we need input from the whole team for an MSRV bump. This PR moves us to 1.71.

- [x] [@adamgreig](https://github.com/adamgreig)
- [ ] [@bartmassey](https://github.com/BartMassey)
- [ ] [@berkus](https://github.com/berkus)
- [x] [@jonathanpallant](https://github.com/jonathanpallant)
- [ ] [@nchong-at-aws](https://github.com/nchong-at-aws)
- [ ] [@newAM](https://github.com/newAM)
- [ ] [@raw-bin](https://github.com/raw-bin)
- [x] [@robamu](https://github.com/robamu)
- [ ] [@thalesfragoso](https://github.com/thalesfragoso)
- [ ] [@therealprof](https://github.com/therealprof)
- [ ] [@ithinuel](https://github.com/ithinuel)
- [ ] [@davidtwco](https://github.com/davidtwco)
