### PR TITLE
doc: add missing ; in _stext example

### DIFF
--- a/cortex-m-rt/src/lib.rs
+++ b/cortex-m-rt/src/lib.rs
@@ -110,7 +110,7 @@
 //! }
 //!
 //! /* The device stores Flash configuration in 0x400-0x40C so we place .text after that */
-//! _stext = ORIGIN(FLASH) + 0x40C
+//! _stext = ORIGIN(FLASH) + 0x40C;
 //! ```
 //!
 //! # An example


### PR DESCRIPTION
In the doc, the `_stext` example lacks a `;` at the end.

Hopefully, this will avoid frustration to other linker-script newbies.