### PR TITLE
Run clippy against Arm build targets.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Run tests
-        run: cargo test --all --exclude cortex-m-rt --exclude testsuite --features cortex-m/critical-section-single-core
+        run: cargo test --workspace --exclude cortex-m-rt --exclude testsuite --features cortex-m/critical-section-single-core

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,11 +5,51 @@ on:
 
 name: Clippy check
 jobs:
-  clippy:
+  clippy_std_code:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85
+      - uses: dtolnay/rust-toolchain@1.94.0
         with:
+          # toolchain: 1.94.0
           components: clippy
-      - run: cargo clippy --workspace --features cortex-m/critical-section-single-core -- --deny warnings
+      - name: Run clippy
+        run: cargo clippy --workspace --features cortex-m/critical-section-single-core -- --deny warnings
+  clippy_cortex_crates:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        # All generated code should be running on stable now
+        rust: [1.94.0]
+        target:
+          [
+            "thumbv8m.main-none-eabihf",
+            "thumbv8m.main-none-eabi",
+            "thumbv8m.base-none-eabi",
+
+            "thumbv7em-none-eabihf",
+            "thumbv7em-none-eabi",
+            "thumbv7m-none-eabi",
+
+            "thumbv6m-none-eabi",
+          ]
+
+        #   # Test nightly but don't fail
+        # - rust: nightly
+        #   experimental: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          components: clippy
+      - name: Run clippy
+        # The excluded packages require std.
+        run: >-
+          cargo clippy --workspace
+          --exclude cortex-m-macros
+          --exclude testsuite
+          --exclude xtask
+          --features cortex-m/critical-section-single-core --target ${{matrix.target}} -- --deny warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85
         with:
           components: clippy
-      - run: cargo clippy --all --features cortex-m/critical-section-single-core -- --deny warnings
+      - run: cargo clippy --workspace --features cortex-m/critical-section-single-core -- --deny warnings


### PR DESCRIPTION
The current clippy runs are running against an X86 build of the code This will make clippy exercise the Arm specfic code. I have only enabled 2 as some jobs were cancelled when I enabled all 7 targets.