### PR TITLE
Add cortex-m-rt/macros to the workspace members.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "cortex-m/macros",
     "cortex-m-types",
     "cortex-m-rt",
+    "cortex-m-rt/macros",
     "cortex-m-semihosting",
     "panic-itm",
     "panic-semihosting",


### PR DESCRIPTION
This is a small change adding the cortex-m-rt-macros crate directory to the workspace members. 

There is a issue in cargo where crates that are created within directories of other crates are not added as members of a workspace (See [here](https://github.com/rust-lang/cargo/issues/16755)). I wonder if that's how this happened.