### PR TITLE
Remove all clippy issues when targeting `thumbv6m-none-eabi`.

### DIFF
--- a/cortex-m/src/peripheral/dwt.rs
+++ b/cortex-m/src/peripheral/dwt.rs
@@ -64,10 +64,15 @@ pub struct Comparator {
 
 // DWT CTRL register fields
 const NUMCOMP_OFFSET: u32 = 28;
+#[cfg(not(armv6m))]
 const NOTRCPKT: u32 = 1 << 27;
+#[cfg(not(armv6m))]
 const NOEXTTRIG: u32 = 1 << 26;
+#[cfg(not(armv6m))]
 const NOCYCCNT: u32 = 1 << 25;
+#[cfg(not(armv6m))]
 const NOPRFCNT: u32 = 1 << 24;
+#[cfg(not(armv6m))]
 const CYCCNTENA: u32 = 1 << 0;
 
 impl DWT {

--- a/cortex-m/src/peripheral/scb.rs
+++ b/cortex-m/src/peripheral/scb.rs
@@ -5,6 +5,7 @@ use core::arch::asm;
 use core::ptr;
 #[cfg(any(armv7m, armv8m))]
 use core::sync::atomic::{Ordering, compiler_fence};
+#[cfg(not(armv6m))]
 use cortex_m_macros::asm_cfg;
 use volatile_register::RW;
 


### PR DESCRIPTION
These clippy issue do not appear when building under non-arm targets, so they have been missed.

Unblocks: #630