### PR TITLE
Document deprecation of inline-asm feature

### DIFF
--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -33,12 +33,13 @@ optional = true
 [features]
 cm7 = []
 cm7-r0p1 = ["cm7"]
-inline-asm = []
 linker-plugin-lto = []
 std = []
 critical-section-single-core = ["critical-section/restore-state-u32"]
 # Deprecated feature from when critical-section was an optional dependency
 critical-section = []
+# Deprecated feature from when inline-asm was optional (to preserve a lower MSRV)
+inline-asm = []
 
 [package.metadata.docs.rs]
 targets = [

--- a/cortex-m/src/lib.rs
+++ b/cortex-m/src/lib.rs
@@ -9,22 +9,6 @@
 //!
 //! # Optional features
 //!
-//! ## `inline-asm`
-//!
-//! When this feature is enabled the implementation of all the functions inside the `asm` and
-//! `register` modules use inline assembly (`asm!`) instead of external assembly (FFI into separate
-//! assembly files pre-compiled using `arm-none-eabi-gcc`). The advantages of enabling `inline-asm`
-//! are:
-//!
-//! - Reduced overhead. FFI eliminates the possibility of inlining so all operations include a
-//!   function call overhead when `inline-asm` is not enabled.
-//!
-//! - Some of the `register` API only becomes available only when `inline-asm` is enabled. Check the
-//!   API docs for details.
-//!
-//! The disadvantage is that `inline-asm` requires a Rust version at least 1.59 to use the `asm!()`
-//! macro. In the future 0.8 and above versions of `cortex-m`, this feature will always be enabled.
-//!
 //! ## `critical-section-single-core`
 //!
 //! This feature enables a [`critical-section`](https://github.com/rust-embedded/critical-section)
@@ -49,8 +33,7 @@
 //! ## `linker-plugin-lto`
 //!
 //! This feature links against prebuilt assembly blobs that are compatible with [Linker-Plugin LTO].
-//! This allows inlining assembly routines into the caller, even without the `inline-asm` feature,
-//! and works on stable Rust (but note the drawbacks below!).
+//! This allows inlining assembly routines into the caller, and works on stable Rust (but note the drawbacks below!).
 //!
 //! If you want to use this feature, you need to be aware of a few things:
 //!
@@ -65,6 +48,12 @@
 //!
 //! [Linker-Plugin LTO]: https://doc.rust-lang.org/stable/rustc/linker-plugin-lto.html
 //! [rust-lang/rust#75940]: https://github.com/rust-lang/rust/issues/75940
+//!
+//! ## `inline-asm`
+//!
+//! This feature is deprecated.
+//! Enabling this feature does nothing - it exists for backwards-compatibility only.
+//! It will be removed in a future version of this crate.
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!

--- a/cortex-m/src/register/apsr.rs
+++ b/cortex-m/src/register/apsr.rs
@@ -49,8 +49,6 @@ impl Apsr {
 }
 
 /// Reads the CPU register
-///
-/// **NOTE** This function is available if `cortex-m` is built with the `"inline-asm"` feature.
 #[inline]
 #[asm_cfg(cortex_m)]
 pub fn read() -> Apsr {

--- a/cortex-m/src/register/lr.rs
+++ b/cortex-m/src/register/lr.rs
@@ -5,8 +5,6 @@ use core::arch::asm;
 use cortex_m_macros::asm_cfg;
 
 /// Reads the CPU register
-///
-/// **NOTE** This function is available if `cortex-m` is built with the `"inline-asm"` feature.
 #[inline]
 #[asm_cfg(cortex_m)]
 pub fn read() -> u32 {
@@ -16,8 +14,6 @@ pub fn read() -> u32 {
 }
 
 /// Writes `bits` to the CPU register
-///
-/// **NOTE** This function is available if `cortex-m` is built with the `"inline-asm"` feature.
 ///
 /// # Safety
 /// This function can't be used soundly.

--- a/cortex-m/src/register/pc.rs
+++ b/cortex-m/src/register/pc.rs
@@ -5,8 +5,6 @@ use core::arch::asm;
 use cortex_m_macros::asm_cfg;
 
 /// Reads the CPU register
-///
-/// **NOTE** This function is available if `cortex-m` is built with the `"inline-asm"` feature.
 #[inline]
 #[asm_cfg(cortex_m)]
 pub fn read() -> u32 {
@@ -16,8 +14,6 @@ pub fn read() -> u32 {
 }
 
 /// Writes `bits` to the CPU register
-///
-/// **NOTE** This function is available if `cortex-m` is built with the `"inline-asm"` feature.
 #[inline]
 #[asm_cfg(cortex_m)]
 pub unsafe fn write(bits: u32) {

--- a/xtask/tests/ci.rs
+++ b/xtask/tests/ci.rs
@@ -44,7 +44,7 @@ fn build(package: &str, target: &str, features: &[&str]) {
 
 #[rustfmt::skip]
 static PACKAGE_FEATURES: &[(&str, &[&str], &[&str])] = &[
-    ("cortex-m", ALL_TARGETS, &["inline-asm", "cm7-r0p1", "critical-section-single-core"]), // no `linker-plugin-lto` since it's experimental
+    ("cortex-m", ALL_TARGETS, &["cm7-r0p1", "critical-section-single-core"]), // no `linker-plugin-lto` since it's experimental
     ("cortex-m-semihosting", ALL_TARGETS, &["no-semihosting", "jlink-quirks"]),
     ("panic-semihosting", ALL_TARGETS, &["exit", "jlink-quirks"]),
     ("panic-itm", NON_BASE_TARGETS, &[]),


### PR DESCRIPTION
Add deprecation notice for `inline-asm` to readme and feature declaration in Cargo.toml.
Remove documentation for deprecated feature `inline-asm` in the rest of this crate.

Reasonable first steps for #644

