### PR TITLE
use cortex-m-types in NVIC

### DIFF
--- a/cortex-m/CHANGELOG.md
+++ b/cortex-m/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `enter_unprivileged` function to switch to unprivileged mode (on the Process Stack, or `PSP`)
 - Updated references from 'Cortex-M Team' to 'Arm Team'
 
+## Changed
+
+- Removed `bare_metal::interrupt::Nr` blanket implementation of `InterruptNumber`
+
 ## [v0.7.7] - 2023-01-03
 
 - Add missing documentation for `critical-section-single-core` feature added

--- a/cortex-m/CHANGELOG.md
+++ b/cortex-m/CHANGELOG.md
@@ -56,6 +56,10 @@ Library crates generally **should not** enable a critical section implementation
 - `SCB::vect_active()` now reads ICSR with a volatile access, preventing the load from being narrowed
   to a byte read that faults on word-only ICSR models.
 
+## Changed
+
+- Removed `bare_metal::interrupt::Nr` blanket implementation of `InterruptNumber`
+
 ## [v0.7.7] - 2023-01-03
 
 - Add missing documentation for `critical-section-single-core` feature added

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -20,6 +20,7 @@ bitfield = "0.13.2"
 eh0 = { package = "embedded-hal", version = "0.2.4" }
 eh1 = { package = "embedded-hal", version = "1.0.0" }
 cortex-m-macros = { path = "macros", version = "=0.1.0" }
+cortex-m-types = { path = "../cortex-m-types", version = "0.1" }
 
 [dependencies.serde]
 version = "1"

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -20,6 +20,7 @@ bitfield = "0.13.2"
 eh0 = { package = "embedded-hal", version = "0.2.4" }
 eh1 = { package = "embedded-hal", version = "1.0.0" }
 cortex-m-macros = { path = "macros", version = "=0.7.8" }
+cortex-m-types = { path = "../cortex-m-types", version = "0.1" }
 
 [dependencies.serde]
 version = "1"

--- a/cortex-m/src/interrupt.rs
+++ b/cortex-m/src/interrupt.rs
@@ -21,6 +21,10 @@ use cortex_m_macros::asm_cfg;
 /// and must always return the same value (do not change at runtime).
 ///
 /// These requirements ensure safe nesting of critical sections.
+#[deprecated(
+    since = "0.8.0",
+    note = "Implement the cortex_m_types::InterruptNumber trait instead"
+)]
 pub unsafe trait InterruptNumber: Copy {
     /// Return the interrupt number associated with this variant.
     ///
@@ -28,12 +32,12 @@ pub unsafe trait InterruptNumber: Copy {
     fn number(self) -> u16;
 }
 
-/// Implement InterruptNumber for the old bare_metal::Nr trait.
-/// This implementation is for backwards compatibility only and will be removed in cortex-m 0.8.
-unsafe impl<T: Nr + Copy> InterruptNumber for T {
+// This trait is only here for backwards compatibility.
+#[allow(deprecated)]
+unsafe impl<T: cortex_m_types::InterruptNumber> InterruptNumber for T {
     #[inline]
     fn number(self) -> u16 {
-        self.nr() as u16
+        <Self as cortex_m_types::InterruptNumber>::number(self) as u16
     }
 }
 

--- a/cortex-m/src/peripheral/nvic.rs
+++ b/cortex-m/src/peripheral/nvic.rs
@@ -1,10 +1,10 @@
 //! Nested Vector Interrupt Controller
 
+pub use cortex_m_types::InterruptNumber;
 use volatile_register::RW;
 #[cfg(not(armv6m))]
 use volatile_register::{RO, WO};
 
-use crate::interrupt::InterruptNumber;
 use crate::peripheral::NVIC;
 
 /// Register block
@@ -101,7 +101,7 @@ impl NVIC {
         let nr = interrupt.number();
 
         unsafe {
-            self.stir.write(u32::from(nr));
+            self.stir.write(nr as u32);
         }
     }
 
@@ -113,7 +113,7 @@ impl NVIC {
     {
         let nr = interrupt.number();
         // NOTE(unsafe) this is a write to a stateless register
-        unsafe { (*Self::PTR).icer[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).icer[nr / 32].write(1 << (nr % 32)) }
     }
 
     /// Enables `interrupt`
@@ -127,7 +127,7 @@ impl NVIC {
         unsafe {
             let nr = interrupt.number();
             // NOTE(ptr) this is a write to a stateless register
-            (*Self::PTR).iser[usize::from(nr / 32)].write(1 << (nr % 32))
+            (*Self::PTR).iser[nr / 32].write(1 << (nr % 32))
         }
     }
 
@@ -145,7 +145,7 @@ impl NVIC {
         {
             let nr = interrupt.number();
             // NOTE(unsafe) atomic read with no side effects
-            unsafe { (*Self::PTR).ipr[usize::from(nr)].read() }
+            unsafe { (*Self::PTR).ipr[nr].read() }
         }
 
         #[cfg(armv6m)]
@@ -168,7 +168,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::PTR).iabr[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).iabr[nr / 32].read() & mask) == mask }
     }
 
     /// Checks if `interrupt` is enabled
@@ -181,7 +181,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::PTR).iser[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).iser[nr / 32].read() & mask) == mask }
     }
 
     /// Checks if `interrupt` is pending
@@ -194,7 +194,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::PTR).ispr[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).ispr[nr / 32].read() & mask) == mask }
     }
 
     /// Forces `interrupt` into pending state
@@ -206,7 +206,7 @@ impl NVIC {
         let nr = interrupt.number();
 
         // NOTE(unsafe) atomic stateless write; ICPR doesn't store any state
-        unsafe { (*Self::PTR).ispr[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).ispr[nr / 32].write(1 << (nr % 32)) }
     }
 
     /// Sets the "priority" of `interrupt` to `prio`
@@ -230,7 +230,7 @@ impl NVIC {
             #[cfg(not(armv6m))]
             {
                 let nr = interrupt.number();
-                self.ipr[usize::from(nr)].write(prio)
+                self.ipr[nr].write(prio)
             }
 
             #[cfg(armv6m)]
@@ -254,7 +254,7 @@ impl NVIC {
         let nr = interrupt.number();
 
         // NOTE(unsafe) atomic stateless write; ICPR doesn't store any state
-        unsafe { (*Self::PTR).icpr[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).icpr[nr / 32].write(1 << (nr % 32)) }
     }
 
     #[cfg(armv6m)]
@@ -263,7 +263,7 @@ impl NVIC {
     where
         I: InterruptNumber,
     {
-        usize::from(interrupt.number()) / 4
+        interrupt.number() / 4
     }
 
     #[cfg(armv6m)]
@@ -272,6 +272,6 @@ impl NVIC {
     where
         I: InterruptNumber,
     {
-        (usize::from(interrupt.number()) % 4) * 8
+        (interrupt.number() % 4) * 8
     }
 }

--- a/cortex-m/src/peripheral/nvic.rs
+++ b/cortex-m/src/peripheral/nvic.rs
@@ -1,10 +1,10 @@
 //! Nested Vector Interrupt Controller
 
+pub use cortex_m_types::InterruptNumber;
 use volatile_register::RW;
 #[cfg(not(armv6m))]
 use volatile_register::{RO, WO};
 
-use crate::interrupt::InterruptNumber;
 use crate::peripheral::NVIC;
 
 /// Register block
@@ -101,7 +101,7 @@ impl NVIC {
         let nr = interrupt.number();
 
         unsafe {
-            self.stir.write(u32::from(nr));
+            self.stir.write(nr as u32);
         }
     }
 
@@ -113,7 +113,7 @@ impl NVIC {
     {
         let nr = interrupt.number();
         // NOTE(unsafe) this is a write to a stateless register
-        unsafe { (*Self::PTR).icer[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).icer[nr / 32].write(1 << (nr % 32)) }
     }
 
     /// Enables `interrupt`
@@ -127,7 +127,7 @@ impl NVIC {
         unsafe {
             let nr = interrupt.number();
             // NOTE(ptr) this is a write to a stateless register
-            (*Self::PTR).iser[usize::from(nr / 32)].write(1 << (nr % 32))
+            (*Self::PTR).iser[nr / 32].write(1 << (nr % 32))
         }
     }
 
@@ -145,7 +145,7 @@ impl NVIC {
         {
             let nr = interrupt.number();
             // NOTE(unsafe) atomic read with no side effects
-            unsafe { (*Self::PTR).ipr[usize::from(nr)].read() }
+            unsafe { (*Self::PTR).ipr[nr].read() }
         }
 
         #[cfg(armv6m)]
@@ -168,7 +168,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::PTR).iabr[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).iabr[nr / 32].read() & mask) == mask }
     }
 
     /// Checks if `interrupt` is enabled
@@ -181,7 +181,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::PTR).iser[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).iser[nr / 32].read() & mask) == mask }
     }
 
     /// Checks if `interrupt` is pending
@@ -194,7 +194,7 @@ impl NVIC {
         let mask = 1 << (nr % 32);
 
         // NOTE(unsafe) atomic read with no side effects
-        unsafe { ((*Self::PTR).ispr[usize::from(nr / 32)].read() & mask) == mask }
+        unsafe { ((*Self::PTR).ispr[nr / 32].read() & mask) == mask }
     }
 
     /// Forces `interrupt` into pending state
@@ -206,7 +206,7 @@ impl NVIC {
         let nr = interrupt.number();
 
         // NOTE(unsafe) atomic stateless write; ICPR doesn't store any state
-        unsafe { (*Self::PTR).ispr[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).ispr[nr / 32].write(1 << (nr % 32)) }
     }
 
     /// Sets the "priority" of `interrupt` to `prio`
@@ -230,7 +230,7 @@ impl NVIC {
             #[cfg(not(armv6m))]
             {
                 let nr = interrupt.number();
-                self.ipr[usize::from(nr)].write(prio)
+                self.ipr[nr].write(prio)
             }
 
             #[cfg(armv6m)]
@@ -254,7 +254,7 @@ impl NVIC {
         let nr = interrupt.number();
 
         // NOTE(unsafe) atomic stateless write; ICPR doesn't store any state
-        unsafe { (*Self::PTR).icpr[usize::from(nr / 32)].write(1 << (nr % 32)) }
+        unsafe { (*Self::PTR).icpr[nr / 32].write(1 << (nr % 32)) }
     }
 
     /// Route `interrupt` to the Non-Secure world (ARMv8-M only).
@@ -317,7 +317,7 @@ impl NVIC {
     where
         I: InterruptNumber,
     {
-        usize::from(interrupt.number()) / 4
+        interrupt.number() / 4
     }
 
     #[cfg(armv6m)]
@@ -326,6 +326,6 @@ impl NVIC {
     where
         I: InterruptNumber,
     {
-        (usize::from(interrupt.number()) % 4) * 8
+        (interrupt.number() % 4) * 8
     }
 }


### PR DESCRIPTION
The InterruptNumber blanket impl for `cortex_m_types::InterruptNumber` is not compatible with the one for all types implementing bare_metal::Nr . removing the other blanket impl is probably a breaking change? :/