### PR TITLE
fix: read ICSR volatile in SCB::vect_active()

### DIFF
--- a/cortex-m/CHANGELOG.md
+++ b/cortex-m/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The code should be clippy clean on all supported configurations now.
 - Add embedded-hal 1.0 delays.
 
+### Fixed
+- `SCB::vect_active()` now reads ICSR with a volatile access, preventing the load from being narrowed
+  to a byte read that faults on word-only ICSR models.
+
 ## [v0.7.7] - 2023-01-03
 
 - Add missing documentation for `critical-section-single-core` feature added

--- a/cortex-m/src/peripheral/scb.rs
+++ b/cortex-m/src/peripheral/scb.rs
@@ -2,7 +2,6 @@
 
 #[cfg(any(armv7m, armv8m))]
 use core::arch::asm;
-use core::ptr;
 #[cfg(any(armv7m, armv8m))]
 use core::sync::atomic::{Ordering, compiler_fence};
 #[cfg(not(armv6m))]
@@ -175,7 +174,7 @@ impl SCB {
     /// Returns the active exception number
     #[inline]
     pub fn vect_active() -> VectActive {
-        let icsr = unsafe { ptr::read(&(*SCB::PTR).icsr as *const _ as *const u32) };
+        let icsr = unsafe { (*SCB::PTR).icsr.read() };
 
         // NOTE(unsafe): Assume correctly selected target.
         unsafe { VectActive::from(icsr as u8).unwrap_unchecked() }


### PR DESCRIPTION
`SCB::vect_active()` now reads ICSR with a volatile access, preventing the load from being narrowed to a byte read that faults on word-only ICSR models.