### PR TITLE
Improve TrustZone support

### DIFF
--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -40,6 +40,8 @@ critical-section-single-core = ["critical-section/restore-state-u32"]
 critical-section = []
 # Deprecated feature from when inline-asm was optional (to preserve a lower MSRV)
 inline-asm = []
+# Add NS variants of various Cortex-M peripherals, which secure mode might want to configure
+secure-mode = []
 
 [package.metadata.docs.rs]
 targets = [

--- a/cortex-m/src/peripheral/mod.rs
+++ b/cortex-m/src/peripheral/mod.rs
@@ -139,6 +139,13 @@ pub struct Peripherals {
     /// System Control Block
     pub SCB: SCB,
 
+    /// Nonsecure alias for System Control Block
+    ///
+    /// This lets a CPU running in Secure mode access the Nonsecure System Control
+    /// Block, without switching to Nonsecure mode to do so.
+    #[cfg(feature = "secure-mode")]
+    pub SCBNS: SCBNS,
+
     /// SysTick: System Timer
     pub SYST: SYST,
 
@@ -213,6 +220,10 @@ impl Peripherals {
                     _marker: PhantomData,
                 },
                 SCB: SCB {
+                    _marker: PhantomData,
+                },
+                #[cfg(feature = "secure-mode")]
+                SCBNS: SCBNS {
                     _marker: PhantomData,
                 },
                 SYST: SYST {
@@ -614,6 +625,34 @@ impl SCB {
 
 impl ops::Deref for SCB {
     type Target = self::scb::RegisterBlock;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+
+/// Nonsecure alias for the System Control Block
+///
+/// This lets a CPU running in Secure mode access the Nonsecure System Control
+/// Block, without switching to Nonsecure mode to do so.
+#[cfg(feature = "secure-mode")]
+pub struct SCBNS {
+    _marker: core::marker::PhantomData<*const ()>,
+}
+
+#[cfg(feature = "secure-mode")]
+unsafe impl Send for SCBNS {}
+
+#[cfg(feature = "secure-mode")]
+impl SCBNS {
+    /// Pointer to the nonsecure alias for the register block
+    pub const PTR: *const scb::RegisterBlock = 0xE002_ED04 as *const _;
+}
+
+#[cfg(feature = "secure-mode")]
+impl ops::Deref for SCBNS {
+    type Target = scb::RegisterBlock;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/cortex-m/src/peripheral/sau.rs
+++ b/cortex-m/src/peripheral/sau.rs
@@ -83,14 +83,23 @@ bitfield! {
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct Sfsr(u32);
-    invep, _: 0;
-    invis, _: 1;
-    inver, _: 2;
-    auviol, _: 3;
-    invtran, _: 4;
-    lsperr, _: 5;
-    sfarvalid, _: 6;
-    lserr, _: 7;
+    impl Debug;
+    /// Invalid Entry Point
+    pub invep, _: 0;
+    /// Invalid Integrity Signature
+    pub invis, _: 1;
+    /// Invalid Exception Return
+    pub inver, _: 2;
+    /// Attribution Unit Violation
+    pub auviol, _: 3;
+    /// Invalid Transition
+    pub invtran, _: 4;
+    /// Lazy state preservation error
+    pub lsperr, _: 5;
+    /// SFAR is valid
+    pub sfarvalid, _: 6;
+    /// Lazy state error
+    pub lserr, _: 7;
 }
 
 bitfield! {
@@ -98,8 +107,12 @@ bitfield! {
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct Sfar(u32);
+    impl Debug;
     u32;
-    address, _: 31, 0;
+    /// Faulting memory address
+    ///
+    /// Only valid if SFSR.SFARVALID = 1
+    pub address, _: 31, 0;
 }
 
 /// Possible attribute of a SAU region.


### PR DESCRIPTION
Improves TrustZone support, for anyone writing a secure mode application.

- Add secure-mode feature, to enable access to SCB_NS peripheral
- Allow access to SFAR and SFSR fields

With this I can write a useful handler for SecureFault exceptions, and I can
set the VTOR for nonsecure mode from my secure mode bootloader.


