### PR TITLE
docs(msrv): unify rust-version to 1.85 across workspace

### DIFF
--- a/cortex-m-rt/macros/Cargo.toml
+++ b/cortex-m-rt/macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "cortex-m-rt-macros"
 repository = "https://github.com/rust-embedded/cortex-m"
 version = "0.7.5"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.85"
 
 [lib]
 proc-macro = true

--- a/cortex-m/macros/Cargo.toml
+++ b/cortex-m/macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cortex-m-macros"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Fixes #659 . Unified rust-version to 1.85 across all subcrates in workspace to match core cortex-m package.