### PR TITLE
Update cortex-m-semihosting and panic-semihosting for release

### DIFF
--- a/cortex-m-semihosting/CHANGELOG.md
+++ b/cortex-m-semihosting/CHANGELOG.md
@@ -5,8 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.6.0] - 2026-07-20
+
 - MSRV bumped to 1.85
 - Updated references from 'Cortex-M Team' to 'Arm Team'
+- Now uses `critical_section::Mutex` rather than `cortex_m::interrupt::free`
 
 ## [v0.5.0] - 2022-03-01
 
@@ -149,7 +152,8 @@ change.
 
 - Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.5.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.6.0...HEAD
+[v0.6.0]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.5.0...c-m-sh-v0.6.0
 [v0.5.0]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.4.1...c-m-sh-v0.5.0
 [v0.4.1]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.4.0...c-m-sh-v0.4.1
 [v0.4.0]: https://github.com/rust-embedded/cortex-m/compare/c-m-sh-v0.3.5...c-m-sh-v0.4.0

--- a/cortex-m-semihosting/Cargo.toml
+++ b/cortex-m-semihosting/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-semihosting"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 

--- a/panic-semihosting/CHANGELOG.md
+++ b/panic-semihosting/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.7.0] - 2026-07-20
+
 - MSRV bumped to 1.85
 - Updated references from 'Cortex-M Team' to 'Arm Team'
+- Now uses `cortex-m-semihosting` version 0.6, which uses
+  `critical_section::Mutex` rather than `cortex_m::interrupt::free`
 
 ## [v0.6.0] - 2022-03-01
 
@@ -77,7 +81,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/p-sh-v0.6.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/panic-semihosting/compare/p-sh-v0.7.0...HEAD
+[v0.7.0]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.6.0...p-sh-v0.7.0
 [v0.6.0]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.5.6...p-sh-v0.6.0
 [v0.5.6]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.5.5...p-sh-v0.5.6
 [v0.5.5]: https://github.com/rust-embedded/cortex-m/compare/p-sh-v0.5.4...p-sh-v0.5.5

--- a/panic-semihosting/Cargo.toml
+++ b/panic-semihosting/Cargo.toml
@@ -6,13 +6,13 @@ keywords = ["panic-handler", "panic-impl", "panic", "semihosting"]
 license = "MIT OR Apache-2.0"
 name = "panic-semihosting"
 repository = "https://github.com/rust-embedded/cortex-m"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
 cortex-m = { path = "../cortex-m", version = ">= 0.5.6, < 0.8" }
-cortex-m-semihosting = { path = "../cortex-m-semihosting", version = ">= 0.5.0, < 0.6" }
+cortex-m-semihosting = { path = "../cortex-m-semihosting", version = "0.6" }
 
 [features]
 exit = []


### PR DESCRIPTION
cortex-m-semihosting goes to 0.6, because it now requires critical-section.

panic-semihosting goes to 0.7 because it uses cortex-m-semihosting, and so also now requires critical-section.