### PR TITLE
Release cortex-m

### DIFF
--- a/cortex-m/CHANGELOG.md
+++ b/cortex-m/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.7.8] - 2026-07-21
+
 ### Deprecated
 - The `inline-asm` feature is now a currently a no-op, will be removed in a future major version
 
@@ -778,7 +780,8 @@ fn main() {
 - Functions to get the vector table
 - Wrappers over miscellaneous instructions like `bkpt`
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.7...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.7.8...HEAD
+[v0.7.8]: https://github.com/rust-embedded/cortex-m/compare/v0.7.7...v0.7.8
 [v0.7.7]: https://github.com/rust-embedded/cortex-m/compare/v0.7.6...v0.7.7
 [v0.7.6]: https://github.com/rust-embedded/cortex-m/compare/v0.7.5...v0.7.6
 [v0.7.5]: https://github.com/rust-embedded/cortex-m/compare/v0.7.4...v0.7.5

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -19,7 +19,7 @@ volatile-register = "0.2.2"
 bitfield = "0.13.2"
 eh0 = { package = "embedded-hal", version = "0.2.4" }
 eh1 = { package = "embedded-hal", version = "1.0.0" }
-cortex-m-macros = { path = "macros", version = "=0.1.0" }
+cortex-m-macros = { path = "macros", version = "=0.7.8" }
 
 [dependencies.serde]
 version = "1"

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -8,7 +8,7 @@ name = "cortex-m"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m"
 edition = "2024"
-version = "0.7.7"
+version = "0.7.8"
 links = "cortex-m"  # prevent multiple versions of this crate to be linked together
 rust-version = "1.85"
 

--- a/cortex-m/macros/Cargo.toml
+++ b/cortex-m/macros/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
+categories = ["embedded", "no-std"]
+description = "Attributes used by `cortex-m`"
+documentation = "https://docs.rs/cortex-m-rt"
+license = "MIT OR Apache-2.0"
 name = "cortex-m-macros"
-version = "0.1.0"
+repository = "https://github.com/rust-embedded/cortex-m"
+version = "0.7.8"
 edition = "2024"
 rust-version = "1.85"
 

--- a/cortex-m/src/asm.rs
+++ b/cortex-m/src/asm.rs
@@ -465,10 +465,13 @@ core::arch::global_asm!(
 );
 
 /// This instruction moves one Register to a Coprocessor Register.
+///
 /// This function generates inline assembly and needs the instruction configuration
 /// during compilation time (i.e. as `const`).
+///
 /// The values of the constants required by this function should be defined by
 /// the coprocessor's reference manual.
+///
 ///  - CP: The coprocessor's index.
 ///  - OP1: First optional operation for the coprocessor.
 ///  - CRN: Coprocessor register N.
@@ -494,10 +497,13 @@ pub unsafe fn mcr<const CP: u32, const OP1: u32, const CRN: u32, const CRM: u32,
 }
 
 /// This instruction moves one Coprocessor Register to a Register.
+///
 /// This function generates inline assembly and needs the instruction configuration
 /// during compilation time (i.e. as `const`).
+///
 /// The values of the constants required by this function should be defined by
 /// the coprocessor's reference manual.
+///
 ///  - CP: The coprocessor's index.
 ///  - OP1: First optional operation for the coprocessor.
 ///  - CRN: Coprocessor register N.
@@ -526,10 +532,13 @@ pub unsafe fn mrc<const CP: u32, const OP1: u32, const CRN: u32, const CRM: u32,
 }
 
 /// This instruction moves two Registers to Coprocessor Registers.
+///
 /// This function generates inline assembly and needs the instruction configuration
 /// during compilation time (i.e. as `const`).
+///
 /// The values of the constants required by this function should be defined by
 /// the coprocessor's reference manual.
+///
 ///  - CP: The coprocessor's index.
 ///  - OP1: First optional operation for the coprocessor.
 ///  - CRM: Coprocessor register M.
@@ -550,10 +559,13 @@ pub unsafe fn mcrr<const CP: u32, const OP1: u32, const CRM: u32>(a: u32, b: u32
 }
 
 /// This instruction moves two Coprocessor Registers to Registers.
+///
 /// This function generates inline assembly and needs the instruction configuration
 /// during compilation time (i.e. as `const`).
+///
 /// The values of the constants required by this function should be defined by
 /// the coprocessor's reference manual.
+///
 ///  - CP: The coprocessor's index.
 ///  - OP1: First optional operation for the coprocessor.
 ///  - CRM: Coprocessor register M.

--- a/cortex-m/src/asm.rs
+++ b/cortex-m/src/asm.rs
@@ -453,7 +453,6 @@ core::arch::global_asm!(
         mov     r6, 0
         mov     r7, 0
         mov     r8, 0
-        mov     r8, 0
         mov     r9, 0
         mov     r10, 0
         mov     r11, 0

--- a/cortex-m/src/cmse.rs
+++ b/cortex-m/src/cmse.rs
@@ -4,7 +4,7 @@
 //! Extensions.
 //! Most of this implementation is directly inspired by the "Armv8-M Security Extensions:
 //! Requirements on Development Tools" document available here:
-//! https://developer.arm.com/docs/ecm0359818/latest
+//! <https://developer.arm.com/docs/ecm0359818/latest>
 //!
 //! Please note that the TT instructions support as described part 4 of the document linked above is
 //! not part of CMSE but is still present in this module. The TT instructions return the

--- a/cortex-m/src/lib.rs
+++ b/cortex-m/src/lib.rs
@@ -49,6 +49,12 @@
 //! [Linker-Plugin LTO]: https://doc.rust-lang.org/stable/rustc/linker-plugin-lto.html
 //! [rust-lang/rust#75940]: https://github.com/rust-lang/rust/issues/75940
 //!
+//! ## `secure-mode`
+//!
+//! Adds extra non-secure peripherals to the `Peripherals` struct. Only set when your
+//! processor is running in Secure mode, and you need to control operations in nonsecure
+//! mode (e.g. to bootload some nonsecure firmware).
+//!
 //! ## `inline-asm`
 //!
 //! This feature is deprecated.

--- a/cortex-m/src/peripheral/mod.rs
+++ b/cortex-m/src/peripheral/mod.rs
@@ -37,7 +37,7 @@
 //! let cyccnt = DWT::cycle_count();
 //! ```
 //!
-//! The singleton property can be *unsafely* bypassed using the `ptr` static method which is
+//! The singleton property can be *unsafely* bypassed using the `PTR` associated const which is
 //! available on all the peripheral types. This method is a useful building block for implementing
 //! safe higher level abstractions.
 //!

--- a/cortex-m/src/peripheral/sau.rs
+++ b/cortex-m/src/peripheral/sau.rs
@@ -161,11 +161,13 @@ impl SAU {
 
     /// Disable the SAU and mark all memory Non-Secure (ALLNS mode).
     ///
-    /// Sets `CTRL.ALLNS = 1`, `CTRL.ENABLE = 0`. When the SAU is disabled with ALLNS set, the
-    /// entire address space is treated as Non-Secure (subject to any IDAU overrides). Use this
-    /// when running entirely in Non-Secure mode with no security boundary enforcement.
+    /// Sets `CTRL.ALLNS = 1`, `CTRL.ENABLE = 0`. When the SAU is disabled with
+    /// ALLNS set, the entire address space is treated as Non-Secure (subject to
+    /// any IDAU overrides). Use this when running entirely in Non-Secure mode
+    /// with no security boundary enforcement.
     ///
-    /// To re-enable security boundaries, call [`init`] or [`enable`] after programming regions.
+    /// To re-enable security boundaries, call [`init`](Self::init) or
+    /// [`enable`](Self::enable) after programming regions.
     #[inline]
     pub fn disable_allns(&mut self) {
         unsafe {
@@ -175,21 +177,27 @@ impl SAU {
 
     /// Program SAU regions and enable the SAU.
     ///
-    /// This is a convenience wrapper around [`set_region`] + [`enable`]:
+    /// This is a convenience wrapper around [`set_region`](Self::set_region) +
+    /// [`enable`](Self::enable):
+    ///
     /// 1. Disables the SAU temporarily.
     /// 2. Programs all regions from `regions`.
     /// 3. Re-enables the SAU.
     ///
-    /// Memory not covered by any enabled region is treated as Secure once the SAU is enabled.
+    /// Memory not covered by any enabled region is treated as Secure once the
+    /// SAU is enabled.
     ///
-    /// To also enable the `SecureFault` exception so TrustZone violations surface as a dedicated
-    /// fault rather than escalating to `HardFault`, call
-    /// `scb.enable(cortex_m::peripheral::scb::Exception::SecureFault)` after this.
+    /// To also enable the `SecureFault` exception so TrustZone violations
+    /// surface as a dedicated fault rather than escalating to `HardFault`, call
+    /// `scb.enable(cortex_m::peripheral::scb::Exception::SecureFault)` after
+    /// this.
     ///
     /// # Errors
-    /// Returns [`SauError::TooManyRegions`] if `regions.len()` exceeds the number of regions
-    /// implemented in hardware (see [`region_numbers`]). Returns other [`SauError`] variants if
-    /// any region descriptor has a misaligned base or limit address.
+    /// Returns [`SauError::TooManyRegions`] if `regions.len()` exceeds the
+    /// number of regions implemented in hardware (see
+    /// [`region_numbers`](Self::region_numbers). Returns other [`SauError`]
+    /// variants if any region descriptor has a misaligned base or limit
+    /// address.
     ///
     /// On error the SAU is left disabled (in the state set at step 1 above).
     #[inline]

--- a/cortex-m/src/register/primask.rs
+++ b/cortex-m/src/register/primask.rs
@@ -40,7 +40,7 @@ pub fn read() -> Primask {
 }
 
 /// Reads the entire PRIMASK register
-/// Note that bits [31:1] are reserved and UNK (Unknown)
+/// Note that bits `[31:1]` are reserved and UNK (Unknown)
 #[inline]
 #[asm_cfg(cortex_m)]
 pub fn read_raw() -> u32 {
@@ -50,7 +50,8 @@ pub fn read_raw() -> u32 {
 }
 
 /// Writes the entire PRIMASK register
-/// Note that bits [31:1] are reserved and SBZP (Should-Be-Zero-or-Preserved)
+///
+/// Note that bits `[31:1]` are reserved and SBZP (Should-Be-Zero-or-Preserved)
 ///
 /// # Safety
 ///


### PR DESCRIPTION
* Updates cortex-m and cortex-m-macros to 0.7.8
* ~~Updates cortex-m-rt and cortex-m-rt macros to 0.7.6~~ (pulled into #675)
* Added relevant headers to both CHANGELOGs
* Fixed a bunch of doc issues that CI missed (`cargo doc --target=thumbv8m.main-none-eabihf` is now clean)
