### PR TITLE
secure routing API for NVIC now takes exclusive reference

### DIFF
--- a/cortex-m/src/peripheral/nvic.rs
+++ b/cortex-m/src/peripheral/nvic.rs
@@ -268,14 +268,14 @@ impl NVIC {
     /// while Secure handlers depend on it can violate security invariants.
     #[cfg(armv8m)]
     #[inline]
-    pub unsafe fn route_to_nonsecure<I>(interrupt: I)
+    pub unsafe fn route_to_nonsecure<I>(&mut self, interrupt: I)
     where
         I: InterruptNumber,
     {
         let nr = interrupt.number();
         let group_idx = usize::from(nr / 32);
         let bit_mask = 1 << (nr % 32);
-        unsafe { (*Self::PTR).itns[group_idx].modify(|v| v | bit_mask) }
+        unsafe { self.itns[group_idx].modify(|v| v | bit_mask) }
     }
 
     /// Route `interrupt` back to the Secure world (ARMv8-M only).
@@ -287,14 +287,14 @@ impl NVIC {
     /// Must be called from the Secure world.
     #[cfg(armv8m)]
     #[inline]
-    pub unsafe fn route_to_secure<I>(interrupt: I)
+    pub unsafe fn route_to_secure<I>(&mut self, interrupt: I)
     where
         I: InterruptNumber,
     {
         let nr = interrupt.number();
         let group_idx = usize::from(nr / 32);
         let bit_mask = 1 << (nr % 32);
-        unsafe { (*Self::PTR).itns[group_idx].modify(|v| v & !bit_mask) }
+        unsafe { self.itns[group_idx].modify(|v| v & !bit_mask) }
     }
 
     /// Returns `true` if `interrupt` is routed to the Non-Secure world (ARMv8-M only).


### PR DESCRIPTION
these methods do a non-atomic operation because they modify the register. In the `set_priority` method which also does a register modification, the method takes exclusive reference by taking &mut self. maybe we should do the same here? if not, we should either update the safety note, or update `set_priority` to be consistent.