### PR TITLE
refactor(macros): bump `syn` to v3

### DIFF
--- a/cortex-m-rt/macros/Cargo.toml
+++ b/cortex-m-rt/macros/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro2 = "1.0"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
-version = "2.0"
+version = "3.0"

--- a/cortex-m-rt/macros/src/lib.rs
+++ b/cortex-m-rt/macros/src/lib.rs
@@ -240,7 +240,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
-    if f.sig.unsafety.is_none() {
+    if !matches!(f.sig.safety, syn::Safety::Unsafe(_)) {
         match exn {
             Exception::DefaultHandler | Exception::HardFault(_) | Exception::NonMaskableInt => {
                 // These are unsafe to define.
@@ -635,7 +635,7 @@ pub fn pre_init(args: TokenStream, input: TokenStream) -> TokenStream {
     // check the function signature
     let valid_signature = f.sig.constness.is_none()
         && f.vis == Visibility::Inherited
-        && f.sig.unsafety.is_some()
+        && matches!(f.sig.safety, syn::Safety::Unsafe(_))
         && f.sig.abi.is_none()
         && f.sig.inputs.is_empty()
         && f.sig.generics.params.is_empty()

--- a/cortex-m/macros/Cargo.toml
+++ b/cortex-m/macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.106"
 quote = "1.0.45"
-syn = { version = "2.0.117", features = ["extra-traits", "full"] }
+syn = { version = "3.0", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
 macrotest = "1.2.1"


### PR DESCRIPTION
Following the [release of a new major version of `syn`](https://github.com/dtolnay/syn/releases/tag/3.0.0), this bumps the version used by `cortex-m-macros` and `cortex-m-rt-macros`, with the goal of eventually removing the duplicated dependency in binaries (and therefore reducing compile times).

`syn` v3 advertises an [MSRV of 1.71](https://crates.io/crates/syn/3.0.0/code/Cargo.toml#L14), so this shouldn't affect the MSRV of these crates given the recent bump to 1.85.

I've gone through the changelog and did the necessary refactor; I didn't find any other relevant breaking changes (but there are quite a few of them so I could have missed some). I've run `cargo test` but didn't do any other kind of testing.