### PR TITLE
cortex-m: don't gate off modules for native target

### DIFF
--- a/cortex-m/src/register/mod.rs
+++ b/cortex-m/src/register/mod.rs
@@ -30,15 +30,15 @@
 //!
 //! - Cortex-M* Devices Generic User Guide - Section 2.1.3 Core registers
 
-#[cfg(any(armv7m, armv8m_main))]
+#[cfg(any(armv7m, armv8m_main, native))]
 pub mod basepri;
 
-#[cfg(any(armv7m, armv8m_main))]
+#[cfg(any(armv7m, armv8m_main, native))]
 pub mod basepri_max;
 
 pub mod control;
 
-#[cfg(any(armv7m, armv8m_main))]
+#[cfg(any(armv7m, armv8m_main, native))]
 pub mod faultmask;
 
 #[cfg(has_fpu)]


### PR DESCRIPTION
These modules only contain `asm_cfg`s that explicitly exist to allow for compilation (but not function) on native targets.

Gating the modules behind target features makes this impossible (requiring workarounds on the end of the cortex-m consumer).

The modules should also be made available when compiling for the host target.

Fixes #680 

There are additional modules that might benefit from this, but that are likely not to have compiled before (so I'm not fixing them in this PR): 

* `register::fpscr`. This has some `cfg`'d functions that need the `asm_cfg` treatment.
* `register::msplim` and `register::psplim`. Has some functions that need the `asm_cfg` treatment.
* `itm`. This one I'm having a hard time understanding. It seems like it should work, but I feel that there may be something that I'm missing, so I won't touch it for now.
* `csme`. This has correctly `asm_cfg`'d blocks, but includes a (doc?) test that starts failing if the module is enabled for `cfg(native)`. 